### PR TITLE
feature: add main open input test helper

### DIFF
--- a/packages/test-worker/src/parts/TestFrameWorkComponentMain/TestFrameWorkComponentMain.ts
+++ b/packages/test-worker/src/parts/TestFrameWorkComponentMain/TestFrameWorkComponentMain.ts
@@ -41,6 +41,35 @@ type SavedState = {
   readonly layout?: LayoutState
 }
 
+type EditorInput =
+  | {
+      readonly type: 'editor'
+      readonly uri: string
+    }
+  | {
+      readonly type: 'image'
+      readonly uri: string
+    }
+  | {
+      readonly type: 'video'
+      readonly uri: string
+    }
+  | {
+      readonly type: 'diff-editor'
+      readonly uriLeft: string
+      readonly uriRight: string
+    }
+  | {
+      readonly extensionId: string
+      readonly type: 'extension-detail-view'
+    }
+
+export interface OpenInputOptions {
+  readonly editorInput: EditorInput
+  readonly focu: boolean
+  readonly preview?: boolean
+}
+
 const isObject = (value: unknown): value is Record<string, unknown> => {
   return typeof value === 'object' && value !== null && !Array.isArray(value) && !(value instanceof RegExp)
 }
@@ -111,6 +140,10 @@ const serializeForError = (value: unknown): string => {
 
 export const openUri = async (uri: string): Promise<void> => {
   await RendererWorker.invoke('Main.openUri', uri)
+}
+
+export const openInput = async (options: OpenInputOptions): Promise<void> => {
+  await RendererWorker.invoke('Main.openInput', options)
 }
 
 export const saveState = async (uid: number): Promise<SavedState> => {

--- a/packages/test-worker/test/TestFrameWorkComponentMain.test.ts
+++ b/packages/test-worker/test/TestFrameWorkComponentMain.test.ts
@@ -41,6 +41,68 @@ test('openUri', async () => {
   expect(mockRpc.invocations).toEqual([['Main.openUri', 'file:///test.txt']])
 })
 
+test('openInput', async () => {
+  using mockRpc = RendererWorker.registerMockRpc({
+    'Main.openInput'() {
+      return undefined
+    },
+  })
+
+  await Main.openInput({
+    editorInput: {
+      type: 'editor',
+      uri: 'file:///test.txt',
+    },
+    focu: false,
+    preview: false,
+  })
+
+  expect(mockRpc.invocations).toEqual([
+    [
+      'Main.openInput',
+      {
+        editorInput: {
+          type: 'editor',
+          uri: 'file:///test.txt',
+        },
+        focu: false,
+        preview: false,
+      },
+    ],
+  ])
+})
+
+test('openInput forwards diff editor input', async () => {
+  using mockRpc = RendererWorker.registerMockRpc({
+    'Main.openInput'() {
+      return undefined
+    },
+  })
+
+  await Main.openInput({
+    editorInput: {
+      type: 'diff-editor',
+      uriLeft: 'file:///left.txt',
+      uriRight: 'file:///right.txt',
+    },
+    focu: false,
+  })
+
+  expect(mockRpc.invocations).toEqual([
+    [
+      'Main.openInput',
+      {
+        editorInput: {
+          type: 'diff-editor',
+          uriLeft: 'file:///left.txt',
+          uriRight: 'file:///right.txt',
+        },
+        focu: false,
+      },
+    ],
+  ])
+})
+
 test('saveState', async () => {
   using mockRpc = RendererWorker.registerMockRpc({
     'Main.saveState'() {


### PR DESCRIPTION
Adds a Main.openInput test helper that forwards main-area OpenInputOptions so tests can open editor, diff, extension detail, image, and video inputs through the same command shape.