### PR TITLE
fix: normalize windows temporary file uris

### DIFF
--- a/packages/test-worker/src/parts/TestFrameWorkComponentFileSystem/TestFrameWorkComponentFileSystem.ts
+++ b/packages/test-worker/src/parts/TestFrameWorkComponentFileSystem/TestFrameWorkComponentFileSystem.ts
@@ -106,9 +106,22 @@ export const remove = async (uri: string): Promise<void> => {
   await RendererWorker.invoke('FileSystem.remove', uri)
 }
 
+const windowsPathRegex = /^[A-Za-z]:\//
+
+const toFileUri = (path: string): string => {
+  if (path.startsWith('file://')) {
+    return path
+  }
+  const normalizedPath = path.replaceAll('\\', '/')
+  if (windowsPathRegex.test(normalizedPath)) {
+    return `file:///${normalizedPath}`
+  }
+  return `file://${normalizedPath}`
+}
+
 const getTmpDirFileScheme = async (): Promise<string> => {
   const tmpFolder = await RendererWorker.invoke('PlatformPaths.getTmpDir')
-  const tmpUri = tmpFolder.startsWith('file://') ? tmpFolder : `file://${tmpFolder}`
+  const tmpUri = toFileUri(tmpFolder)
   const uri = `${tmpUri}/test-${Date.now()}`
   await mkdir(uri)
   return uri

--- a/packages/test-worker/test/TestFrameWorkComponentFileSystem.test.ts
+++ b/packages/test-worker/test/TestFrameWorkComponentFileSystem.test.ts
@@ -167,6 +167,23 @@ test('getTmpDir: file scheme keeps existing file protocol', async () => {
   dateNowMock.mockRestore()
 })
 
+test('getTmpDir: file scheme normalizes a windows path', async () => {
+  const dateNowMock = jest.spyOn(Date, 'now').mockReturnValue(123)
+  using mockRpc = RendererWorker.registerMockRpc({
+    'FileSystem.mkdir'() {
+      return undefined
+    },
+    'PlatformPaths.getTmpDir'() {
+      return String.raw`C:\Users\test\AppData\Local\Temp`
+    },
+  })
+
+  const tmpDir: string = await FileSystem.getTmpDir({ scheme: 'file' })
+  expect(tmpDir).toBe('file:///C:/Users/test/AppData/Local/Temp/test-123')
+  expect(mockRpc.invocations).toEqual([['PlatformPaths.getTmpDir'], ['FileSystem.mkdir', 'file:///C:/Users/test/AppData/Local/Temp/test-123']])
+  dateNowMock.mockRestore()
+})
+
 test('getTmpDir: default scheme uses platform tmp dir', async () => {
   using mockRpc = RendererWorker.registerMockRpc({
     'PlatformPaths.getTmpDir'() {


### PR DESCRIPTION
## Summary
- normalize Windows temporary directory paths to canonical file URIs
- preserve existing file URIs and POSIX path behavior
- add regression coverage for Windows drive-letter paths

## Verification
- npm run lint
- npm run type-check
- TMPDIR=/home/simon/.cache/git-isolated-tmp npm --prefix packages/test-worker test -- --runInBand (1125 passed, 1 skipped)