### PR TITLE
feature: add running extensions page object

### DIFF
--- a/packages/test-worker/src/parts/Api/Api.ts
+++ b/packages/test-worker/src/parts/Api/Api.ts
@@ -40,6 +40,7 @@ import type * as ProcessExplorer from '../TestFrameWorkComponentProcessExplorer/
 import type * as QuickPick from '../TestFrameWorkComponentQuickPick/TestFrameWorkComponentQuickPick.ts'
 import type * as References from '../TestFrameWorkComponentReferences/TestFrameWorkComponentReferences.ts'
 import type * as RunAndDebug from '../TestFrameWorkComponentRunAndDebug/TestFrameWorkComponentRunAndDebug.ts'
+import type * as RunningExtensions from '../TestFrameWorkComponentRunningExtensions/TestFrameWorkComponentRunningExtensions.ts'
 import type * as Search from '../TestFrameWorkComponentSearch/TestFrameWorkComponentSearch.ts'
 import type * as Settings from '../TestFrameWorkComponentSettings/TestFrameWorkComponentSettings.ts'
 import type * as SettingsView from '../TestFrameWorkComponentSettingsView/TestFrameWorkComponentSettingsView.ts'
@@ -105,6 +106,7 @@ export interface Api {
   QuickPick: typeof QuickPick
   References: typeof References
   RunAndDebug: typeof RunAndDebug
+  RunningExtensions: typeof RunningExtensions
   Search: typeof Search
   Settings: typeof Settings
   SettingsView: typeof SettingsView

--- a/packages/test-worker/src/parts/CreateApi/CreateApi.ts
+++ b/packages/test-worker/src/parts/CreateApi/CreateApi.ts
@@ -40,6 +40,7 @@ import * as ProcessExplorer from '../TestFrameWorkComponentProcessExplorer/TestF
 import * as QuickPick from '../TestFrameWorkComponentQuickPick/TestFrameWorkComponentQuickPick.ts'
 import * as References from '../TestFrameWorkComponentReferences/TestFrameWorkComponentReferences.ts'
 import * as RunAndDebug from '../TestFrameWorkComponentRunAndDebug/TestFrameWorkComponentRunAndDebug.ts'
+import * as RunningExtensions from '../TestFrameWorkComponentRunningExtensions/TestFrameWorkComponentRunningExtensions.ts'
 import * as Search from '../TestFrameWorkComponentSearch/TestFrameWorkComponentSearch.ts'
 import * as Settings from '../TestFrameWorkComponentSettings/TestFrameWorkComponentSettings.ts'
 import * as SettingsView from '../TestFrameWorkComponentSettingsView/TestFrameWorkComponentSettingsView.ts'
@@ -107,6 +108,7 @@ export const createApi = (platform: number, assetDir: string): Api => {
     QuickPick,
     References,
     RunAndDebug,
+    RunningExtensions,
     Search,
     Settings,
     SettingsView,

--- a/packages/test-worker/src/parts/TestFrameWorkComponent/TestFrameWorkComponent.ts
+++ b/packages/test-worker/src/parts/TestFrameWorkComponent/TestFrameWorkComponent.ts
@@ -39,6 +39,7 @@ export * as Problems from '../TestFrameWorkComponentProblems/TestFrameWorkCompon
 export * as QuickPick from '../TestFrameWorkComponentQuickPick/TestFrameWorkComponentQuickPick.ts'
 export * as References from '../TestFrameWorkComponentReferences/TestFrameWorkComponentReferences.ts'
 export * as RunAndDebug from '../TestFrameWorkComponentRunAndDebug/TestFrameWorkComponentRunAndDebug.ts'
+export * as RunningExtensions from '../TestFrameWorkComponentRunningExtensions/TestFrameWorkComponentRunningExtensions.ts'
 export * as Search from '../TestFrameWorkComponentSearch/TestFrameWorkComponentSearch.ts'
 export * as Settings from '../TestFrameWorkComponentSettings/TestFrameWorkComponentSettings.ts'
 export * as SettingsView from '../TestFrameWorkComponentSettingsView/TestFrameWorkComponentSettingsView.ts'

--- a/packages/test-worker/src/parts/TestFrameWorkComponentRunningExtensions/TestFrameWorkComponentRunningExtensions.ts
+++ b/packages/test-worker/src/parts/TestFrameWorkComponentRunningExtensions/TestFrameWorkComponentRunningExtensions.ts
@@ -20,6 +20,10 @@ export const disableWorkspace = async (index: number): Promise<void> => {
   await RendererWorker.invoke('RunningExtensions.disableWorkspace', index)
 }
 
+export const reportIssue = async (index: number): Promise<void> => {
+  await RendererWorker.invoke('RunningExtensions.reportIssue', index)
+}
+
 export const startProfile = async (): Promise<void> => {
   await RendererWorker.invoke('RunningExtensions.startProfile')
 }

--- a/packages/test-worker/src/parts/TestFrameWorkComponentRunningExtensions/TestFrameWorkComponentRunningExtensions.ts
+++ b/packages/test-worker/src/parts/TestFrameWorkComponentRunningExtensions/TestFrameWorkComponentRunningExtensions.ts
@@ -1,0 +1,25 @@
+import { RendererWorker } from '@lvce-editor/rpc-registry'
+
+export const show = async (): Promise<void> => {
+  await RendererWorker.invoke('Main.openUri', 'running-extensions:///1')
+}
+
+export const handleContextMenu = async (index: number, x: number = 0, y: number = 0): Promise<void> => {
+  await RendererWorker.invoke('RunningExtensions.handleContextMenu', index, x, y)
+}
+
+export const copyId = async (index: number): Promise<void> => {
+  await RendererWorker.invoke('RunningExtensions.copyId', index)
+}
+
+export const disable = async (index: number): Promise<void> => {
+  await RendererWorker.invoke('RunningExtensions.disable', index)
+}
+
+export const disableWorkspace = async (index: number): Promise<void> => {
+  await RendererWorker.invoke('RunningExtensions.disableWorkspace', index)
+}
+
+export const startProfile = async (): Promise<void> => {
+  await RendererWorker.invoke('RunningExtensions.startProfile')
+}

--- a/packages/test-worker/test/CreateApi.test.ts
+++ b/packages/test-worker/test/CreateApi.test.ts
@@ -48,6 +48,7 @@ test('createApi includes all expected components', () => {
   expect(api.QuickPick).toBeDefined()
   expect(api.References).toBeDefined()
   expect(api.RunAndDebug).toBeDefined()
+  expect(api.RunningExtensions).toBeDefined()
   expect(api.Search).toBeDefined()
   expect(api.Settings).toBeDefined()
   expect(api.StatusBar).toBeDefined()

--- a/packages/test-worker/test/TestFrameWorkComponentRunningExtensions.test.ts
+++ b/packages/test-worker/test/TestFrameWorkComponentRunningExtensions.test.ts
@@ -1,0 +1,32 @@
+import { expect, test } from '@jest/globals'
+import { RendererWorker } from '@lvce-editor/rpc-registry'
+import * as RunningExtensions from '../src/parts/TestFrameWorkComponentRunningExtensions/TestFrameWorkComponentRunningExtensions.ts'
+
+test('commands', async () => {
+  using mockRpc = RendererWorker.registerMockRpc({
+    'Main.openUri'() {},
+    'RunningExtensions.copyId'() {},
+    'RunningExtensions.disable'() {},
+    'RunningExtensions.disableWorkspace'() {},
+    'RunningExtensions.handleContextMenu'() {},
+    'RunningExtensions.startProfile'() {},
+  })
+
+  await RunningExtensions.show()
+  await RunningExtensions.handleContextMenu(1, 10, 20)
+  await RunningExtensions.handleContextMenu(2)
+  await RunningExtensions.copyId(3)
+  await RunningExtensions.disable(4)
+  await RunningExtensions.disableWorkspace(5)
+  await RunningExtensions.startProfile()
+
+  expect(mockRpc.invocations).toEqual([
+    ['Main.openUri', 'running-extensions:///1'],
+    ['RunningExtensions.handleContextMenu', 1, 10, 20],
+    ['RunningExtensions.handleContextMenu', 2, 0, 0],
+    ['RunningExtensions.copyId', 3],
+    ['RunningExtensions.disable', 4],
+    ['RunningExtensions.disableWorkspace', 5],
+    ['RunningExtensions.startProfile'],
+  ])
+})

--- a/packages/test-worker/test/TestFrameWorkComponentRunningExtensions.test.ts
+++ b/packages/test-worker/test/TestFrameWorkComponentRunningExtensions.test.ts
@@ -9,6 +9,7 @@ test('commands', async () => {
     'RunningExtensions.disable'() {},
     'RunningExtensions.disableWorkspace'() {},
     'RunningExtensions.handleContextMenu'() {},
+    'RunningExtensions.reportIssue'() {},
     'RunningExtensions.startProfile'() {},
   })
 
@@ -18,6 +19,7 @@ test('commands', async () => {
   await RunningExtensions.copyId(3)
   await RunningExtensions.disable(4)
   await RunningExtensions.disableWorkspace(5)
+  await RunningExtensions.reportIssue(6)
   await RunningExtensions.startProfile()
 
   expect(mockRpc.invocations).toEqual([
@@ -27,6 +29,7 @@ test('commands', async () => {
     ['RunningExtensions.copyId', 3],
     ['RunningExtensions.disable', 4],
     ['RunningExtensions.disableWorkspace', 5],
+    ['RunningExtensions.reportIssue', 6],
     ['RunningExtensions.startProfile'],
   ])
 })


### PR DESCRIPTION
Adds a RunningExtensions test page object with helpers for opening the view, context menus, copy ID, disable actions, and profiling.