### PR TITLE
feature: reset reused page before tests

### DIFF
--- a/packages/test-worker/src/parts/Test/Test.ts
+++ b/packages/test-worker/src/parts/Test/Test.ts
@@ -93,6 +93,7 @@ const executeAllTest = async (item: ExecuteAllTest, globals: any): Promise<Execu
     if (!test) {
       return getMissingTestResult(item.name)
     }
+    await RendererWorker.invoke('Layout.reset')
     return getExecutedResult(item.name, test, globals)
   } catch (error) {
     return getImportErrorResult(item.name, error)

--- a/packages/test-worker/test/Test.test.ts
+++ b/packages/test-worker/test/Test.test.ts
@@ -170,6 +170,9 @@ export const test = async () => {}
   const href = 'http://localhost:3000/tests/_all.html'
 
   using mockRpc = RendererWorker.registerMockRpc({
+    'Layout.reset'() {
+      return undefined
+    },
     'TestFrameWork.showOverlay'() {
       return undefined
     },
@@ -195,10 +198,12 @@ export const test = async () => {}
     platform: 1,
     url: href,
   })
-  expect(mockRpc.invocations).toHaveLength(2)
-  expect(mockRpc.invocations[0]).toEqual(['TestFrameWork.showOverlay', 'fail', 'red', expect.stringMatching(allTestsMixedSummaryPattern)])
-  expect(mockRpc.invocations[1]?.[0]).toBe('TestFrameWork.showTestResults')
-  const results = JSON.parse(mockRpc.invocations[1]?.[1])
+  expect(mockRpc.invocations).toHaveLength(4)
+  expect(mockRpc.invocations[0]).toEqual(['Layout.reset'])
+  expect(mockRpc.invocations[1]).toEqual(['Layout.reset'])
+  expect(mockRpc.invocations[2]).toEqual(['TestFrameWork.showOverlay', 'fail', 'red', expect.stringMatching(allTestsMixedSummaryPattern)])
+  expect(mockRpc.invocations[3]?.[0]).toBe('TestFrameWork.showTestResults')
+  const results = JSON.parse(mockRpc.invocations[3]?.[1])
   expect(results).toMatchObject([
     {
       error: '',
@@ -257,6 +262,9 @@ export const test = async () => {}
 `)
 
   using mockRpc = RendererWorker.registerMockRpc({
+    'Layout.reset'() {
+      return undefined
+    },
     'TestFrameWork.showOverlay'() {
       return undefined
     },
@@ -275,5 +283,10 @@ export const test = async () => {}
     assetDir,
   )
 
-  expect(mockRpc.invocations[0]).toEqual(['TestFrameWork.showOverlay', 'pass', 'green', expect.stringMatching(allTestsPassedSummaryPattern)])
+  expect(mockRpc.invocations).toEqual([
+    ['Layout.reset'],
+    ['Layout.reset'],
+    ['TestFrameWork.showOverlay', 'pass', 'green', expect.stringMatching(allTestsPassedSummaryPattern)],
+    ['TestFrameWork.showTestResults', expect.any(String)],
+  ])
 })


### PR DESCRIPTION
Reset the application before each runnable test in the reused-page test flow so tests start from an isolated state.