### PR TITLE
feature: add ActivityBar.handleExtensionsChanged helper

### DIFF
--- a/packages/test-worker/src/parts/TestFrameWorkComponentActivityBar/TestFrameworkComponentActivityBar.ts
+++ b/packages/test-worker/src/parts/TestFrameWorkComponentActivityBar/TestFrameworkComponentActivityBar.ts
@@ -46,6 +46,10 @@ export const handleContextMenu = async (): Promise<void> => {
   await RendererWorker.invoke('ActivityBar.handleContextMenu')
 }
 
+export const handleExtensionsChanged = async (): Promise<void> => {
+  await RendererWorker.invoke('ActivityBar.handleExtensionsChanged')
+}
+
 export interface UpdateConfig {
   readonly progress: number
   readonly state: number

--- a/packages/test-worker/test/TestFrameWorkComponentActivityBar.test.ts
+++ b/packages/test-worker/test/TestFrameWorkComponentActivityBar.test.ts
@@ -123,6 +123,17 @@ test('handleContextMenu', async () => {
   expect(mockRpc.invocations).toEqual([['ActivityBar.handleContextMenu']])
 })
 
+test('handleExtensionsChanged', async () => {
+  using mockRpc = RendererWorker.registerMockRpc({
+    'ActivityBar.handleExtensionsChanged'() {
+      return undefined
+    },
+  })
+
+  await ActivityBar.handleExtensionsChanged()
+  expect(mockRpc.invocations).toEqual([['ActivityBar.handleExtensionsChanged']])
+})
+
 test('setUpdateState', async () => {
   using mockRpc = RendererWorker.registerMockRpc({
     'ActivityBar.handleUpdateStateChange'() {


### PR DESCRIPTION
Adds the ActivityBar.handleExtensionsChanged test-worker API helper and verifies that it invokes the matching renderer command.