### PR TITLE
fix: add activity bar context menu arguments

### DIFF
--- a/packages/test-worker/src/parts/TestFrameWorkComponentActivityBar/TestFrameworkComponentActivityBar.ts
+++ b/packages/test-worker/src/parts/TestFrameWorkComponentActivityBar/TestFrameworkComponentActivityBar.ts
@@ -42,8 +42,8 @@ export const handleSideBarHidden = async (): Promise<void> => {
   await RendererWorker.invoke('ActivityBar.handleSideBarHidden')
 }
 
-export const handleContextMenu = async (): Promise<void> => {
-  await RendererWorker.invoke('ActivityBar.handleContextMenu')
+export const handleContextMenu = async (uid: number, button: number, x: number, y: number): Promise<void> => {
+  await RendererWorker.invoke('ActivityBar.handleContextMenu', uid, button, x, y)
 }
 
 export const handleExtensionsChanged = async (): Promise<void> => {

--- a/packages/test-worker/test/TestFrameWorkComponentActivityBar.test.ts
+++ b/packages/test-worker/test/TestFrameWorkComponentActivityBar.test.ts
@@ -119,8 +119,8 @@ test('handleContextMenu', async () => {
     },
   })
 
-  await ActivityBar.handleContextMenu()
-  expect(mockRpc.invocations).toEqual([['ActivityBar.handleContextMenu']])
+  await ActivityBar.handleContextMenu(300, 0, 100, 200)
+  expect(mockRpc.invocations).toEqual([['ActivityBar.handleContextMenu', 300, 0, 100, 200]])
 })
 
 test('handleExtensionsChanged', async () => {


### PR DESCRIPTION
Summary:
- require the activity bar uid and context-menu event arguments
- forward all arguments to the renderer worker and cover their order with a unit test