### PR TITLE
feature: add activity bar account test functions

### DIFF
--- a/packages/test-worker/src/parts/TestFrameWorkComponentActivityBar/TestFrameworkComponentActivityBar.ts
+++ b/packages/test-worker/src/parts/TestFrameWorkComponentActivityBar/TestFrameworkComponentActivityBar.ts
@@ -8,10 +8,12 @@ export const toggleActivityBarItem = async (id: string): Promise<void> => {
   await RendererWorker.invoke('ActivityBar.toggleActivityBarItem', id)
 }
 
-// export type LoginState = 'logging in' | 'logging out'
-
-export const setUserLoginState = async (loginState: string): Promise<void> => {
-  await RendererWorker.invoke('ActivityBar.setUserLoginState', loginState)
+export const setUserLoginState = async (loginState: string, userInfo?: unknown): Promise<void> => {
+  if (userInfo === undefined) {
+    await RendererWorker.invoke('ActivityBar.setUserLoginState', loginState)
+    return
+  }
+  await RendererWorker.invoke('ActivityBar.setUserLoginState', loginState, userInfo)
 }
 
 export const focusFirst = async (): Promise<void> => {
@@ -65,6 +67,10 @@ export const selectCurrent = async (): Promise<void> => {
 
 export const handleClickSettings = async (x: number, y: number): Promise<void> => {
   await RendererWorker.invoke('ActivityBar.handleClickSettings', x, y)
+}
+
+export const handleClickAccount = async (x: number, y: number): Promise<void> => {
+  await RendererWorker.invoke('ActivityBar.handleClickAccount', x, y)
 }
 
 export interface Dimensions {

--- a/packages/test-worker/test/TestFrameWorkComponentActivityBar.test.ts
+++ b/packages/test-worker/test/TestFrameWorkComponentActivityBar.test.ts
@@ -35,6 +35,17 @@ test('setUserLoginState', async () => {
   expect(mockRpc.invocations).toEqual([['ActivityBar.setUserLoginState', 'logging in']])
 })
 
+test('setUserLoginState with user info', async () => {
+  using mockRpc = RendererWorker.registerMockRpc({
+    'ActivityBar.setUserLoginState'() {
+      return undefined
+    },
+  })
+
+  await ActivityBar.setUserLoginState('logged in', { provider: 'GitHub', userName: 'SimonSiefke' })
+  expect(mockRpc.invocations).toEqual([['ActivityBar.setUserLoginState', 'logged in', { provider: 'GitHub', userName: 'SimonSiefke' }]])
+})
+
 test('focusFirst', async () => {
   using mockRpc = RendererWorker.registerMockRpc({
     'ActivityBar.focusFirst'() {
@@ -176,6 +187,17 @@ test('handleClickSettings', async () => {
 
   await ActivityBar.handleClickSettings(100, 200)
   expect(mockRpc.invocations).toEqual([['ActivityBar.handleClickSettings', 100, 200]])
+})
+
+test('handleClickAccount', async () => {
+  using mockRpc = RendererWorker.registerMockRpc({
+    'ActivityBar.handleClickAccount'() {
+      return undefined
+    },
+  })
+
+  await ActivityBar.handleClickAccount(100, 200)
+  expect(mockRpc.invocations).toEqual([['ActivityBar.handleClickAccount', 100, 200]])
 })
 
 test('resize', async () => {


### PR DESCRIPTION
Adds test-worker Activity Bar helpers for setting the user login state with optional account metadata and opening the account menu.