### PR TITLE
feature: add activity bar handle click index helper

### DIFF
--- a/packages/test-worker/src/parts/TestFrameWorkComponentActivityBar/TestFrameworkComponentActivityBar.ts
+++ b/packages/test-worker/src/parts/TestFrameWorkComponentActivityBar/TestFrameworkComponentActivityBar.ts
@@ -1,4 +1,5 @@
 import { RendererWorker } from '@lvce-editor/rpc-registry'
+import * as Command from '../TestFrameWorkComponentCommand/TestFrameWorkComponentCommand.ts'
 
 export const focus = async (): Promise<void> => {
   await RendererWorker.invoke('ActivityBar.focus')
@@ -36,6 +37,10 @@ export const focusPrevious = async (): Promise<void> => {
 
 export const handleClick = async (index: number): Promise<void> => {
   await RendererWorker.invoke('ActivityBar.handleClick', index)
+}
+
+export const handleClickIndex = async (): Promise<void> => {
+  await Command.execute('ActivityBar.handleClickIndex', 0, 1, 0, 0)
 }
 
 export const handleSideBarHidden = async (): Promise<void> => {

--- a/packages/test-worker/test/TestFrameWorkComponentActivityBar.test.ts
+++ b/packages/test-worker/test/TestFrameWorkComponentActivityBar.test.ts
@@ -101,6 +101,17 @@ test('handleClick', async () => {
   expect(mockRpc.invocations).toEqual([['ActivityBar.handleClick', 1]])
 })
 
+test('handleClickIndex', async () => {
+  using mockRpc = RendererWorker.registerMockRpc({
+    'ActivityBar.handleClickIndex'() {
+      return undefined
+    },
+  })
+
+  await ActivityBar.handleClickIndex()
+  expect(mockRpc.invocations).toEqual([['ActivityBar.handleClickIndex', 0, 1, 0, 0]])
+})
+
 test('handleSideBarHidden', async () => {
   using mockRpc = RendererWorker.registerMockRpc({
     'ActivityBar.handleSideBarHidden'() {


### PR DESCRIPTION
Adds an Activity Bar test-framework helper that executes the handle-click-index command for index 1, with focused unit coverage.