### PR TITLE
feature: add activity bar badge count helper

### DIFF
--- a/packages/test-worker/src/parts/TestFrameWorkComponentActivityBar/TestFrameworkComponentActivityBar.ts
+++ b/packages/test-worker/src/parts/TestFrameWorkComponentActivityBar/TestFrameworkComponentActivityBar.ts
@@ -1,4 +1,5 @@
 import { RendererWorker } from '@lvce-editor/rpc-registry'
+import * as Command from '../TestFrameWorkComponentCommand/TestFrameWorkComponentCommand.ts'
 
 export const focus = async (): Promise<void> => {
   await RendererWorker.invoke('ActivityBar.focus')
@@ -48,6 +49,10 @@ export const handleContextMenu = async (uid: number, button: number, x: number, 
 
 export const handleExtensionsChanged = async (): Promise<void> => {
   await RendererWorker.invoke('ActivityBar.handleExtensionsChanged')
+}
+
+export const handleBadgeCountChange = async (): Promise<void> => {
+  await Command.execute('ActivityBar.handleBadgeCountChange', {})
 }
 
 export interface UpdateConfig {

--- a/packages/test-worker/test/TestFrameWorkComponentActivityBar.test.ts
+++ b/packages/test-worker/test/TestFrameWorkComponentActivityBar.test.ts
@@ -134,6 +134,17 @@ test('handleExtensionsChanged', async () => {
   expect(mockRpc.invocations).toEqual([['ActivityBar.handleExtensionsChanged']])
 })
 
+test('handleBadgeCountChange', async () => {
+  using mockRpc = RendererWorker.registerMockRpc({
+    'ActivityBar.handleBadgeCountChange'() {
+      return undefined
+    },
+  })
+
+  await ActivityBar.handleBadgeCountChange()
+  expect(mockRpc.invocations).toEqual([['ActivityBar.handleBadgeCountChange', {}]])
+})
+
 test('setUpdateState', async () => {
   using mockRpc = RendererWorker.registerMockRpc({
     'ActivityBar.handleUpdateStateChange'() {


### PR DESCRIPTION
Adds a test-worker ActivityBar helper that dispatches the badge count change command with an empty change set, including focused invocation coverage.