### PR TITLE
feature: add activity bar settings changed helper

### DIFF
--- a/packages/test-worker/src/parts/TestFrameWorkComponentActivityBar/TestFrameworkComponentActivityBar.ts
+++ b/packages/test-worker/src/parts/TestFrameWorkComponentActivityBar/TestFrameworkComponentActivityBar.ts
@@ -61,6 +61,10 @@ export const handleBadgeCountChange = async (): Promise<void> => {
   await Command.execute('ActivityBar.handleBadgeCountChange', {})
 }
 
+export const handleSettingsChanged = async (): Promise<void> => {
+  await Command.execute('ActivityBar.handleSettingsChanged')
+}
+
 export interface UpdateConfig {
   readonly progress: number
   readonly state: number

--- a/packages/test-worker/test/TestFrameWorkComponentActivityBar.test.ts
+++ b/packages/test-worker/test/TestFrameWorkComponentActivityBar.test.ts
@@ -167,6 +167,17 @@ test('handleBadgeCountChange', async () => {
   expect(mockRpc.invocations).toEqual([['ActivityBar.handleBadgeCountChange', {}]])
 })
 
+test('handleSettingsChanged', async () => {
+  using mockRpc = RendererWorker.registerMockRpc({
+    'ActivityBar.handleSettingsChanged'() {
+      return undefined
+    },
+  })
+
+  await ActivityBar.handleSettingsChanged()
+  expect(mockRpc.invocations).toEqual([['ActivityBar.handleSettingsChanged']])
+})
+
 test('setUpdateState', async () => {
   using mockRpc = RendererWorker.registerMockRpc({
     'ActivityBar.handleUpdateStateChange'() {


### PR DESCRIPTION
Adds a test-worker Activity Bar helper that executes the ActivityBar.handleSettingsChanged command, with unit coverage for command forwarding.