### PR TITLE
feature: add activity bar handle click command

### DIFF
--- a/packages/test-worker/src/parts/TestFrameWorkComponentActivityBar/TestFrameworkComponentActivityBar.ts
+++ b/packages/test-worker/src/parts/TestFrameWorkComponentActivityBar/TestFrameworkComponentActivityBar.ts
@@ -1,4 +1,5 @@
 import { RendererWorker } from '@lvce-editor/rpc-registry'
+import * as Command from '../TestFrameWorkComponentCommand/TestFrameWorkComponentCommand.ts'
 
 export const focus = async (): Promise<void> => {
   await RendererWorker.invoke('ActivityBar.focus')
@@ -34,8 +35,8 @@ export const focusPrevious = async (): Promise<void> => {
   await RendererWorker.invoke('ActivityBar.focusPrevious')
 }
 
-export const handleClick = async (index: number): Promise<void> => {
-  await RendererWorker.invoke('ActivityBar.handleClick', index)
+export const handleClick = async (): Promise<void> => {
+  await Command.execute('ActivityBar.handleClick', 0, -1000, -1000, '')
 }
 
 export const handleSideBarHidden = async (): Promise<void> => {

--- a/packages/test-worker/test/TestFrameWorkComponentActivityBar.test.ts
+++ b/packages/test-worker/test/TestFrameWorkComponentActivityBar.test.ts
@@ -97,8 +97,8 @@ test('handleClick', async () => {
     },
   })
 
-  await ActivityBar.handleClick(1)
-  expect(mockRpc.invocations).toEqual([['ActivityBar.handleClick', 1]])
+  await ActivityBar.handleClick()
+  expect(mockRpc.invocations).toEqual([['ActivityBar.handleClick', 0, -1000, -1000, '']])
 })
 
 test('handleSideBarHidden', async () => {


### PR DESCRIPTION
Updates the Activity Bar test helper to execute the outside-click command with the expected button, coordinates, and target name. Adds focused coverage for the command arguments.