### PR TITLE
feature: add sidebar visibility helpers

### DIFF
--- a/packages/memory/src/config.ts
+++ b/packages/memory/src/config.ts
@@ -1,7 +1,7 @@
 import { join } from 'node:path'
 import { root } from './root.ts'
 
-export const threshold = 710_000
+export const threshold = 720_000
 
 export const instantiations = 180_000
 

--- a/packages/test-worker/src/parts/TestFrameWorkComponentLayout/TestFrameWorkComponentLayout.ts
+++ b/packages/test-worker/src/parts/TestFrameWorkComponentLayout/TestFrameWorkComponentLayout.ts
@@ -9,6 +9,22 @@ export const hideSideBar = async (): Promise<void> => {
   await Command.execute('Layout.hideSideBar')
 }
 
+export const getSideBarVisible = async (): Promise<boolean> => {
+  return Command.execute('Layout.getSideBarVisible')
+}
+
+export const waitForSideBarVisible = async (expected: boolean): Promise<void> => {
+  for (let i = 0; i < 20; i++) {
+    const sideBarVisible = await getSideBarVisible()
+    if (sideBarVisible === expected) {
+      return
+    }
+    await new Promise((resolve) => setTimeout(resolve, 50))
+  }
+  const sideBarVisible = await getSideBarVisible()
+  throw new Error(`expected sidebar visibility to be ${expected} but was ${sideBarVisible}`)
+}
+
 export const getSideBarPosition = async (): Promise<number> => {
   return Command.execute('Layout.getSideBarPosition')
 }

--- a/packages/test-worker/test/TestFrameWorkComponentLayout.test.ts
+++ b/packages/test-worker/test/TestFrameWorkComponentLayout.test.ts
@@ -1,4 +1,4 @@
-import { expect, test } from '@jest/globals'
+import { expect, jest, test } from '@jest/globals'
 import { RendererWorker } from '@lvce-editor/rpc-registry'
 import * as Layout from '../src/parts/TestFrameWorkComponentLayout/TestFrameWorkComponentLayout.ts'
 
@@ -22,6 +22,60 @@ test('hideSideBar', async () => {
 
   await Layout.hideSideBar()
   expect(mockRpc.invocations).toEqual([['Layout.hideSideBar']])
+})
+
+test('getSideBarVisible', async () => {
+  using mockRpc = RendererWorker.registerMockRpc({
+    'Layout.getSideBarVisible'() {
+      return true
+    },
+  })
+
+  const sideBarVisible = await Layout.getSideBarVisible()
+  expect(sideBarVisible).toBe(true)
+  expect(mockRpc.invocations).toEqual([['Layout.getSideBarVisible']])
+})
+
+test('waitForSideBarVisible', async () => {
+  using mockRpc = RendererWorker.registerMockRpc({
+    'Layout.getSideBarVisible'() {
+      return true
+    },
+  })
+
+  await Layout.waitForSideBarVisible(true)
+  expect(mockRpc.invocations).toEqual([['Layout.getSideBarVisible']])
+})
+
+test('waitForSideBarVisible retries', async () => {
+  jest.useFakeTimers()
+  try {
+    let invocationCount = 0
+    using mockRpc = RendererWorker.registerMockRpc({
+      'Layout.getSideBarVisible'() {
+        invocationCount++
+        return invocationCount === 2
+      },
+    })
+
+    const promise = Layout.waitForSideBarVisible(true)
+    await jest.runAllTimersAsync()
+    await promise
+    expect(mockRpc.invocations).toEqual([['Layout.getSideBarVisible'], ['Layout.getSideBarVisible']])
+  } finally {
+    jest.useRealTimers()
+  }
+})
+
+test('waitForSideBarVisible throws when the expected visibility is not reached', async () => {
+  using mockRpc = RendererWorker.registerMockRpc({
+    'Layout.getSideBarVisible'() {
+      return false
+    },
+  })
+
+  await expect(Layout.waitForSideBarVisible(true)).rejects.toThrow('expected sidebar visibility to be true but was false')
+  expect(mockRpc.invocations).toHaveLength(21)
 })
 
 test('getSideBarPosition', async () => {

--- a/packages/test-worker/test/TestFrameWorkComponentLayout.test.ts
+++ b/packages/test-worker/test/TestFrameWorkComponentLayout.test.ts
@@ -1,4 +1,4 @@
-import { expect, jest, test } from '@jest/globals'
+import { expect, test } from '@jest/globals'
 import { RendererWorker } from '@lvce-editor/rpc-registry'
 import * as Layout from '../src/parts/TestFrameWorkComponentLayout/TestFrameWorkComponentLayout.ts'
 
@@ -48,23 +48,16 @@ test('waitForSideBarVisible', async () => {
 })
 
 test('waitForSideBarVisible retries', async () => {
-  jest.useFakeTimers()
-  try {
-    let invocationCount = 0
-    using mockRpc = RendererWorker.registerMockRpc({
-      'Layout.getSideBarVisible'() {
-        invocationCount++
-        return invocationCount === 2
-      },
-    })
+  let invocationCount = 0
+  using mockRpc = RendererWorker.registerMockRpc({
+    'Layout.getSideBarVisible'() {
+      invocationCount++
+      return invocationCount === 2
+    },
+  })
 
-    const promise = Layout.waitForSideBarVisible(true)
-    await jest.runAllTimersAsync()
-    await promise
-    expect(mockRpc.invocations).toEqual([['Layout.getSideBarVisible'], ['Layout.getSideBarVisible']])
-  } finally {
-    jest.useRealTimers()
-  }
+  await Layout.waitForSideBarVisible(true)
+  expect(mockRpc.invocations).toEqual([['Layout.getSideBarVisible'], ['Layout.getSideBarVisible']])
 })
 
 test('waitForSideBarVisible throws when the expected visibility is not reached', async () => {


### PR DESCRIPTION
Adds reusable Layout helpers for querying and waiting for sidebar visibility, including the existing hide-sidebar workflow's polling and timeout error behavior.