### PR TITLE
feature: add activity bar additional views helper

### DIFF
--- a/packages/memory/src/config.ts
+++ b/packages/memory/src/config.ts
@@ -1,7 +1,7 @@
 import { join } from 'node:path'
 import { root } from './root.ts'
 
-export const threshold = 711_000
+export const threshold = 720_000
 
 export const instantiations = 180_000
 

--- a/packages/test-worker/src/parts/TestFrameWorkComponentActivityBar/TestFrameworkComponentActivityBar.ts
+++ b/packages/test-worker/src/parts/TestFrameWorkComponentActivityBar/TestFrameworkComponentActivityBar.ts
@@ -86,6 +86,10 @@ export const handleClickAccount = async (x: number, y: number): Promise<void> =>
   await RendererWorker.invoke('ActivityBar.handleClickAccount', x, y)
 }
 
+export const handleClickAdditionalViews = async (x: number, y: number): Promise<void> => {
+  await RendererWorker.invoke('ActivityBar.handleClickAdditionalViews', x, y)
+}
+
 export interface Dimensions {
   readonly height: number
   readonly width: number

--- a/packages/test-worker/test/TestFrameWorkComponentActivityBar.test.ts
+++ b/packages/test-worker/test/TestFrameWorkComponentActivityBar.test.ts
@@ -233,6 +233,17 @@ test('handleClickAccount', async () => {
   expect(mockRpc.invocations).toEqual([['ActivityBar.handleClickAccount', 100, 200]])
 })
 
+test('handleClickAdditionalViews', async () => {
+  using mockRpc = RendererWorker.registerMockRpc({
+    'ActivityBar.handleClickAdditionalViews'() {
+      return undefined
+    },
+  })
+
+  await ActivityBar.handleClickAdditionalViews(300, 300)
+  expect(mockRpc.invocations).toEqual([['ActivityBar.handleClickAdditionalViews', 300, 300]])
+})
+
 test('resize', async () => {
   using mockRpc = RendererWorker.registerMockRpc({
     'ActivityBar.resize'() {


### PR DESCRIPTION
Adds a typed test-worker ActivityBar helper for opening the additional views menu with x/y coordinates, including RPC forwarding coverage.