### PR TITLE
feature: resize activity bar before tests

### DIFF
--- a/packages/memory/src/config.ts
+++ b/packages/memory/src/config.ts
@@ -1,7 +1,7 @@
 import { join } from 'node:path'
 import { root } from './root.ts'
 
-export const threshold = 710_000
+export const threshold = 711_000
 
 export const instantiations = 180_000
 

--- a/packages/test-worker/src/parts/Test/Test.ts
+++ b/packages/test-worker/src/parts/Test/Test.ts
@@ -9,6 +9,7 @@ import * as ImportTest from '../ImportTest/ImportTest.ts'
 import { printTestError } from '../PrintTestError/PrintTestError.ts'
 import * as ShouldSkipTest from '../ShouldSkipTest/ShouldSkipTest.ts'
 import * as TestFrameWork from '../TestFrameWork/TestFrameWork.ts'
+import * as Command from '../TestFrameWorkComponentCommand/TestFrameWorkComponentCommand.ts'
 import * as TestFrameWorkComponentUrl from '../TestFrameWorkComponentUrl/TestFrameWorkComponentUrl.ts'
 import * as TestInfoCache from '../TestInfoCache/TestInfoCache.ts'
 import * as TestState from '../TestState/TestState.ts'
@@ -94,6 +95,12 @@ const executeAllTest = async (item: ExecuteAllTest, globals: any): Promise<Execu
       return getMissingTestResult(item.name)
     }
     await RendererWorker.invoke('Layout.reset')
+    await Command.execute('ActivityBar.resize', {
+      height: 144,
+      width: 48,
+      x: 0,
+      y: 0,
+    })
     return getExecutedResult(item.name, test, globals)
   } catch (error) {
     return getImportErrorResult(item.name, error)

--- a/packages/test-worker/test/Test.test.ts
+++ b/packages/test-worker/test/Test.test.ts
@@ -170,6 +170,9 @@ export const test = async () => {}
   const href = 'http://localhost:3000/tests/_all.html'
 
   using mockRpc = RendererWorker.registerMockRpc({
+    'ActivityBar.resize'() {
+      return undefined
+    },
     'Layout.reset'() {
       return undefined
     },
@@ -198,12 +201,14 @@ export const test = async () => {}
     platform: 1,
     url: href,
   })
-  expect(mockRpc.invocations).toHaveLength(4)
+  expect(mockRpc.invocations).toHaveLength(6)
   expect(mockRpc.invocations[0]).toEqual(['Layout.reset'])
-  expect(mockRpc.invocations[1]).toEqual(['Layout.reset'])
-  expect(mockRpc.invocations[2]).toEqual(['TestFrameWork.showOverlay', 'fail', 'red', expect.stringMatching(allTestsMixedSummaryPattern)])
-  expect(mockRpc.invocations[3]?.[0]).toBe('TestFrameWork.showTestResults')
-  const results = JSON.parse(mockRpc.invocations[3]?.[1])
+  expect(mockRpc.invocations[1]).toEqual(['ActivityBar.resize', { height: 144, width: 48, x: 0, y: 0 }])
+  expect(mockRpc.invocations[2]).toEqual(['Layout.reset'])
+  expect(mockRpc.invocations[3]).toEqual(['ActivityBar.resize', { height: 144, width: 48, x: 0, y: 0 }])
+  expect(mockRpc.invocations[4]).toEqual(['TestFrameWork.showOverlay', 'fail', 'red', expect.stringMatching(allTestsMixedSummaryPattern)])
+  expect(mockRpc.invocations[5]?.[0]).toBe('TestFrameWork.showTestResults')
+  const results = JSON.parse(mockRpc.invocations[5]?.[1])
   expect(results).toMatchObject([
     {
       error: '',
@@ -262,6 +267,9 @@ export const test = async () => {}
 `)
 
   using mockRpc = RendererWorker.registerMockRpc({
+    'ActivityBar.resize'() {
+      return undefined
+    },
     'Layout.reset'() {
       return undefined
     },
@@ -285,7 +293,9 @@ export const test = async () => {}
 
   expect(mockRpc.invocations).toEqual([
     ['Layout.reset'],
+    ['ActivityBar.resize', { height: 144, width: 48, x: 0, y: 0 }],
     ['Layout.reset'],
+    ['ActivityBar.resize', { height: 144, width: 48, x: 0, y: 0 }],
     ['TestFrameWork.showOverlay', 'pass', 'green', expect.stringMatching(allTestsPassedSummaryPattern)],
     ['TestFrameWork.showTestResults', expect.any(String)],
   ])


### PR DESCRIPTION
Resize the activity bar to its standard 48×144 dimensions after resetting the layout for each runnable test in the reused-page test flow. This keeps activity-bar state deterministic between tests.