### PR TITLE
fix: round final test result timestamps

### DIFF
--- a/packages/test-worker/src/parts/RoundTestResults/RoundTestResults.ts
+++ b/packages/test-worker/src/parts/RoundTestResults/RoundTestResults.ts
@@ -1,0 +1,16 @@
+interface TestResult {
+  readonly end: number
+  readonly start: number
+}
+
+const roundToTwoDecimalPlaces = (value: number): number => {
+  return Math.round(value * 100) / 100
+}
+
+export const roundTestResults = <T extends TestResult>(results: readonly T[]): readonly T[] => {
+  return results.map((result) => ({
+    ...result,
+    end: roundToTwoDecimalPlaces(result.end),
+    start: roundToTwoDecimalPlaces(result.start),
+  }))
+}

--- a/packages/test-worker/src/parts/Test/Test.ts
+++ b/packages/test-worker/src/parts/Test/Test.ts
@@ -7,6 +7,7 @@ import { formatDuration } from '../FormatDuration/FormatDuration.ts'
 import { hotReloadEnabled } from '../HotReloadEnabled/HotReloadEnabled.ts'
 import * as ImportTest from '../ImportTest/ImportTest.ts'
 import { printTestError } from '../PrintTestError/PrintTestError.ts'
+import { roundTestResults } from '../RoundTestResults/RoundTestResults.ts'
 import * as ShouldSkipTest from '../ShouldSkipTest/ShouldSkipTest.ts'
 import * as TestFrameWork from '../TestFrameWork/TestFrameWork.ts'
 import * as Command from '../TestFrameWorkComponentCommand/TestFrameWorkComponentCommand.ts'
@@ -223,7 +224,7 @@ export const executeAll = async (tests: readonly ExecuteAllTest[], href: string,
   }
   const end = Timestamp.now()
   await showAllTestsOverlay(results, end - start)
-  await RendererWorker.invoke('TestFrameWork.showTestResults', JSON.stringify(results))
+  await RendererWorker.invoke('TestFrameWork.showTestResults', JSON.stringify(roundTestResults(results)))
   TestInfoCache.push({
     assetDir,
     inProgress: false,

--- a/packages/test-worker/test/RoundTestResults.test.ts
+++ b/packages/test-worker/test/RoundTestResults.test.ts
@@ -1,0 +1,37 @@
+import { expect, test } from '@jest/globals'
+import { roundTestResults } from '../src/parts/RoundTestResults/RoundTestResults.ts'
+
+test('roundTestResults rounds timestamps to at most two decimal places', () => {
+  const results = roundTestResults([
+    {
+      end: 267.2149999999674,
+      name: 'sample.js',
+      start: 262.89000000001397,
+      status: 'pass',
+    },
+  ])
+
+  expect(results).toEqual([
+    {
+      end: 267.21,
+      name: 'sample.js',
+      start: 262.89,
+      status: 'pass',
+    },
+  ])
+})
+
+test('roundTestResults does not mutate input results', () => {
+  const result = {
+    end: 1.234,
+    start: 0.123,
+  }
+
+  const results = roundTestResults([result])
+
+  expect(results[0]).not.toBe(result)
+  expect(result).toEqual({
+    end: 1.234,
+    start: 0.123,
+  })
+})


### PR DESCRIPTION
Rounds serialized E2E test start and end timestamps to at most two decimal places.