### PR TITLE
fix: support shift keyboard modifier

### DIFF
--- a/packages/test-worker/src/parts/GetKeyOptions/GetKeyOptions.ts
+++ b/packages/test-worker/src/parts/GetKeyOptions/GetKeyOptions.ts
@@ -10,6 +10,10 @@ const applyKeyPart = (part: string, options: any): void => {
       options.ctrlKey = true
       return
     }
+    case Key.Shift: {
+      options.shiftKey = true
+      return
+    }
     case Key.Space: {
       options.key = ' '
       return
@@ -27,6 +31,7 @@ export const getKeyOptions = (rawKey: string): any => {
       altKey: false,
       ctrlKey: false,
       key: '',
+      shiftKey: false,
     }
     for (const part of parts) {
       applyKeyPart(part, options)
@@ -37,5 +42,6 @@ export const getKeyOptions = (rawKey: string): any => {
     altKey: false,
     ctrlKey: false,
     key: rawKey,
+    shiftKey: false,
   }
 }

--- a/packages/test-worker/src/parts/Key/Key.ts
+++ b/packages/test-worker/src/parts/Key/Key.ts
@@ -1,3 +1,4 @@
 export const Control = 'Control'
 export const Space = 'Space'
 export const Alt = 'Alt'
+export const Shift = 'Shift'

--- a/packages/test-worker/test/GetKeyOptions.test.ts
+++ b/packages/test-worker/test/GetKeyOptions.test.ts
@@ -6,6 +6,7 @@ test('key with control', () => {
     altKey: false,
     ctrlKey: true,
     key: 'a',
+    shiftKey: false,
   })
 })
 
@@ -14,6 +15,7 @@ test('key with alt', () => {
     altKey: true,
     ctrlKey: false,
     key: 'a',
+    shiftKey: false,
   })
 })
 
@@ -22,6 +24,16 @@ test('key with space', () => {
     altKey: false,
     ctrlKey: true,
     key: ' ',
+    shiftKey: false,
+  })
+})
+
+test('key with shift', () => {
+  expect(GetKeyOptions.getKeyOptions('Shift+Enter')).toEqual({
+    altKey: false,
+    ctrlKey: false,
+    key: 'Enter',
+    shiftKey: true,
   })
 })
 
@@ -30,5 +42,6 @@ test('normal key', () => {
     altKey: false,
     ctrlKey: false,
     key: 'a',
+    shiftKey: false,
   })
 })

--- a/packages/test-worker/test/TestFrameWorkComponentKeyBoard.test.ts
+++ b/packages/test-worker/test/TestFrameWorkComponentKeyBoard.test.ts
@@ -21,6 +21,7 @@ test('press: simple key', async () => {
         cancelable: true,
         ctrlKey: false,
         key: 'a',
+        shiftKey: false,
       },
     ],
   ])
@@ -45,6 +46,30 @@ test('press: with modifiers Control+Alt+Space', async () => {
         cancelable: true,
         ctrlKey: true,
         key: ' ',
+        shiftKey: false,
+      },
+    ],
+  ])
+})
+
+test('press: with shift modifier', async () => {
+  using mockRpc = RendererWorker.registerMockRpc({
+    'TestFrameWork.performKeyBoardAction'() {
+      return undefined
+    },
+  })
+  await KeyBoard.press('Shift+Enter')
+  expect(mockRpc.invocations).toEqual([
+    [
+      'TestFrameWork.performKeyBoardAction',
+      'press',
+      {
+        altKey: false,
+        bubbles: true,
+        cancelable: true,
+        ctrlKey: false,
+        key: 'Enter',
+        shiftKey: true,
       },
     ],
   ])


### PR DESCRIPTION
Adds `Shift` parsing to the e2e keyboard helper so browser-path tests can exercise shortcuts such as Shift+Enter.

Includes unit coverage for parsing and forwarding the modifier.