### PR TITLE
fix: reset activity bar to full height

### DIFF
--- a/packages/test-worker/src/parts/Test/Test.ts
+++ b/packages/test-worker/src/parts/Test/Test.ts
@@ -97,7 +97,7 @@ const executeAllTest = async (item: ExecuteAllTest, globals: any): Promise<Execu
     }
     await RendererWorker.invoke('Layout.reset')
     await Command.execute('ActivityBar.resize', {
-      height: 144,
+      height: 336,
       width: 48,
       x: 0,
       y: 0,

--- a/packages/test-worker/test/Test.test.ts
+++ b/packages/test-worker/test/Test.test.ts
@@ -203,9 +203,9 @@ export const test = async () => {}
   })
   expect(mockRpc.invocations).toHaveLength(6)
   expect(mockRpc.invocations[0]).toEqual(['Layout.reset'])
-  expect(mockRpc.invocations[1]).toEqual(['ActivityBar.resize', { height: 144, width: 48, x: 0, y: 0 }])
+  expect(mockRpc.invocations[1]).toEqual(['ActivityBar.resize', { height: 336, width: 48, x: 0, y: 0 }])
   expect(mockRpc.invocations[2]).toEqual(['Layout.reset'])
-  expect(mockRpc.invocations[3]).toEqual(['ActivityBar.resize', { height: 144, width: 48, x: 0, y: 0 }])
+  expect(mockRpc.invocations[3]).toEqual(['ActivityBar.resize', { height: 336, width: 48, x: 0, y: 0 }])
   expect(mockRpc.invocations[4]).toEqual(['TestFrameWork.showOverlay', 'fail', 'red', expect.stringMatching(allTestsMixedSummaryPattern)])
   expect(mockRpc.invocations[5]?.[0]).toBe('TestFrameWork.showTestResults')
   const results = JSON.parse(mockRpc.invocations[5]?.[1])
@@ -293,9 +293,9 @@ export const test = async () => {}
 
   expect(mockRpc.invocations).toEqual([
     ['Layout.reset'],
-    ['ActivityBar.resize', { height: 144, width: 48, x: 0, y: 0 }],
+    ['ActivityBar.resize', { height: 336, width: 48, x: 0, y: 0 }],
     ['Layout.reset'],
-    ['ActivityBar.resize', { height: 144, width: 48, x: 0, y: 0 }],
+    ['ActivityBar.resize', { height: 336, width: 48, x: 0, y: 0 }],
     ['TestFrameWork.showOverlay', 'pass', 'green', expect.stringMatching(allTestsPassedSummaryPattern)],
     ['TestFrameWork.showTestResults', expect.any(String)],
   ])


### PR DESCRIPTION
## Summary
- reset the Activity Bar to the full seven-item height before each reused-page test
- update reset-call expectations

The previous 144px reset forced the default Activity Bar into overflow, causing otherwise unrelated tests to see only Explorer, Additional Views, and Settings.

## Verification
- `npm test -- --runInBand Test.test.ts` (24 passed)
- `npm run type-check`
- `git diff --check`

Required by lvce-editor/virtual-dom#522.