### PR TITLE
feature: expand running extensions page object

### DIFF
--- a/packages/test-worker/src/parts/TestFrameWorkComponentRunningExtensions/TestFrameWorkComponentRunningExtensions.ts
+++ b/packages/test-worker/src/parts/TestFrameWorkComponentRunningExtensions/TestFrameWorkComponentRunningExtensions.ts
@@ -1,6 +1,6 @@
 import { RendererWorker } from '@lvce-editor/rpc-registry'
-import { createLocator } from '../CreateLocator/CreateLocator.ts'
 import type { ILocatorExternal } from '../ILocatorExternal/ILocatorExternal.ts'
+import { createLocator } from '../CreateLocator/CreateLocator.ts'
 
 export interface RunningExtension {
   readonly activationEvent: string

--- a/packages/test-worker/src/parts/TestFrameWorkComponentRunningExtensions/TestFrameWorkComponentRunningExtensions.ts
+++ b/packages/test-worker/src/parts/TestFrameWorkComponentRunningExtensions/TestFrameWorkComponentRunningExtensions.ts
@@ -1,7 +1,25 @@
 import { RendererWorker } from '@lvce-editor/rpc-registry'
+import { createLocator } from '../CreateLocator/CreateLocator.ts'
+import type { ILocatorExternal } from '../ILocatorExternal/ILocatorExternal.ts'
+
+export interface RunningExtension {
+  readonly activationEvent: string
+  readonly activationTime: number
+  readonly icon: string
+  readonly id: string
+  readonly isolated?: boolean
+  readonly name: string
+  readonly remoteAuthority?: string
+  readonly version: string
+  readonly workerName?: string
+}
 
 export const show = async (): Promise<void> => {
   await RendererWorker.invoke('Main.openUri', 'running-extensions:///1')
+}
+
+export const setExtensions = async (extensions: readonly RunningExtension[]): Promise<void> => {
+  await RendererWorker.invoke('RunningExtensions.setExtensions', extensions)
 }
 
 export const handleContextMenu = async (index: number, x: number = 0, y: number = 0): Promise<void> => {
@@ -26,4 +44,60 @@ export const reportIssue = async (index: number): Promise<void> => {
 
 export const startProfile = async (): Promise<void> => {
   await RendererWorker.invoke('RunningExtensions.startProfile')
+}
+
+export const root = (): ILocatorExternal => {
+  return createLocator('.RunningExtensions')
+}
+
+export const rows = (): ILocatorExternal => {
+  return createLocator('.RunningExtension')
+}
+
+export const row = (index: number): ILocatorExternal => {
+  return rows().nth(index)
+}
+
+export const selectedRow = (index: number): ILocatorExternal => {
+  return createLocator(`.RunningExtension.ExtensionActive[data-index="${index}"]`)
+}
+
+export const emptyMessage = (): ILocatorExternal => {
+  return createLocator('.RunningExtensionsEmpty')
+}
+
+export const name = (index: number): ILocatorExternal => {
+  return row(index).locator('.RunningExtensionName')
+}
+
+export const version = (index: number): ILocatorExternal => {
+  return row(index).locator('.RunningExtensionVersion')
+}
+
+export const id = (index: number): ILocatorExternal => {
+  return row(index).locator('.RunningExtensionId')
+}
+
+export const activationTime = (index: number): ILocatorExternal => {
+  return row(index).locator('.RunningExtensionActivationTime')
+}
+
+export const activationReason = (index: number): ILocatorExternal => {
+  return row(index).locator('.RunningExtensionActivationReason')
+}
+
+export const remoteAuthority = (index: number): ILocatorExternal => {
+  return row(index).locator('.RunningExtensionRemoteAuthority')
+}
+
+export const icon = (index: number): ILocatorExternal => {
+  return row(index).locator('.RunningExtensionIcon')
+}
+
+export const defaultIcon = (index: number): ILocatorExternal => {
+  return row(index).locator('.RunningExtensionDefaultIcon')
+}
+
+export const select = async (index: number): Promise<void> => {
+  await row(index).click()
 }

--- a/packages/test-worker/test/TestFrameWorkComponentRunningExtensions.test.ts
+++ b/packages/test-worker/test/TestFrameWorkComponentRunningExtensions.test.ts
@@ -2,6 +2,14 @@ import { expect, test } from '@jest/globals'
 import { RendererWorker } from '@lvce-editor/rpc-registry'
 import * as RunningExtensions from '../src/parts/TestFrameWorkComponentRunningExtensions/TestFrameWorkComponentRunningExtensions.ts'
 
+const getSelector = (locator: any): string => {
+  return locator._selector
+}
+
+const getParsed = (locator: any): readonly any[] => {
+  return locator._parsed
+}
+
 test('commands', async () => {
   using mockRpc = RendererWorker.registerMockRpc({
     'Main.openUri'() {},
@@ -10,10 +18,23 @@ test('commands', async () => {
     'RunningExtensions.disableWorkspace'() {},
     'RunningExtensions.handleContextMenu'() {},
     'RunningExtensions.reportIssue'() {},
+    'RunningExtensions.setExtensions'() {},
     'RunningExtensions.startProfile'() {},
   })
 
+  const extensions: readonly RunningExtensions.RunningExtension[] = [
+    {
+      activationEvent: 'onStartupFinished',
+      activationTime: 12.49,
+      icon: '',
+      id: 'sample.extension',
+      name: 'Sample Extension',
+      version: '1.0.0',
+    },
+  ]
+
   await RunningExtensions.show()
+  await RunningExtensions.setExtensions(extensions)
   await RunningExtensions.handleContextMenu(1, 10, 20)
   await RunningExtensions.handleContextMenu(2)
   await RunningExtensions.copyId(3)
@@ -24,6 +45,7 @@ test('commands', async () => {
 
   expect(mockRpc.invocations).toEqual([
     ['Main.openUri', 'running-extensions:///1'],
+    ['RunningExtensions.setExtensions', extensions],
     ['RunningExtensions.handleContextMenu', 1, 10, 20],
     ['RunningExtensions.handleContextMenu', 2, 0, 0],
     ['RunningExtensions.copyId', 3],
@@ -32,4 +54,63 @@ test('commands', async () => {
     ['RunningExtensions.reportIssue', 6],
     ['RunningExtensions.startProfile'],
   ])
+})
+
+test('locator helpers use running extensions selectors', () => {
+  expect(getSelector(RunningExtensions.root())).toBe('.RunningExtensions')
+  expect(getSelector(RunningExtensions.rows())).toBe('.RunningExtension')
+  expect(getSelector(RunningExtensions.row(2))).toBe('.RunningExtension')
+  expect(getSelector(RunningExtensions.selectedRow(2))).toBe('.RunningExtension.ExtensionActive[data-index="2"]')
+  expect(getSelector(RunningExtensions.emptyMessage())).toBe('.RunningExtensionsEmpty')
+  expect(getSelector(RunningExtensions.name(2))).toBe('.RunningExtension .RunningExtensionName')
+  expect(getSelector(RunningExtensions.version(2))).toBe('.RunningExtension .RunningExtensionVersion')
+  expect(getSelector(RunningExtensions.id(2))).toBe('.RunningExtension .RunningExtensionId')
+  expect(getSelector(RunningExtensions.activationTime(2))).toBe('.RunningExtension .RunningExtensionActivationTime')
+  expect(getSelector(RunningExtensions.activationReason(2))).toBe('.RunningExtension .RunningExtensionActivationReason')
+  expect(getSelector(RunningExtensions.remoteAuthority(2))).toBe('.RunningExtension .RunningExtensionRemoteAuthority')
+  expect(getSelector(RunningExtensions.icon(2))).toBe('.RunningExtension .RunningExtensionIcon')
+  expect(getSelector(RunningExtensions.defaultIcon(2))).toBe('.RunningExtension .RunningExtensionDefaultIcon')
+})
+
+test('indexed locator helpers keep nth selectors stable', () => {
+  for (const locator of [
+    RunningExtensions.row(2),
+    RunningExtensions.name(2),
+    RunningExtensions.version(2),
+    RunningExtensions.id(2),
+    RunningExtensions.activationTime(2),
+    RunningExtensions.activationReason(2),
+    RunningExtensions.remoteAuthority(2),
+    RunningExtensions.icon(2),
+    RunningExtensions.defaultIcon(2),
+  ]) {
+    expect(getParsed(locator)).toContainEqual({
+      index: 2,
+      type: 'nth',
+    })
+  }
+})
+
+test('select clicks the requested row', async () => {
+  using mockRpc = RendererWorker.registerMockRpc({
+    'TestFrameWork.performAction'() {},
+  })
+
+  await RunningExtensions.select(2)
+
+  expect(mockRpc.invocations).toHaveLength(1)
+  const [[command, locator, action, options]] = mockRpc.invocations
+  expect(command).toBe('TestFrameWork.performAction')
+  expect(getSelector(locator)).toBe('.RunningExtension')
+  expect(getParsed(locator)).toContainEqual({
+    index: 2,
+    type: 'nth',
+  })
+  expect(action).toBe('click')
+  expect(options).toEqual({
+    bubbles: true,
+    button: 0,
+    cancable: true,
+    detail: 1,
+  })
 })


### PR DESCRIPTION
Adds typed running-extension fixtures, reusable view and row locators, metadata/icon locators, and row selection to the RunningExtensions test page object.