### PR TITLE
feature: connect test worker to renderer process

### DIFF
--- a/packages/test-worker/src/parts/CommandMap/CommandMap.ts
+++ b/packages/test-worker/src/parts/CommandMap/CommandMap.ts
@@ -1,11 +1,13 @@
 import * as ExecuteMockRpcFunction from '../ExecuteMockRpcFunction/ExecuteMockRpcFunction.ts'
 import { handleFileWatcherEvent } from '../HandleFileWatcherEvent/HandleFileWatcherEvent.ts'
+import * as RendererProcess from '../RendererProcess/RendererProcess.ts'
 import * as Test from '../Test/Test.ts'
 import * as TestFrameWorkComponentDialog from '../TestFrameWorkComponentDialog/TestFrameWorkComponentDialog.ts'
 import * as TryAutoFix from '../TryAutoFix/TryAutoFix.ts'
 
 export const commandMap: Record<string, any> = {
   'FileWatcher.handleEvent': handleFileWatcherEvent,
+  'RendererProcess.initialize': RendererProcess.initialize,
   'Test.execute': Test.execute,
   'Test.executeAll': Test.executeAll,
   'Test.executeMock': TestFrameWorkComponentDialog.executeMock,

--- a/packages/test-worker/src/parts/ExecuteTest/ExecuteTest.ts
+++ b/packages/test-worker/src/parts/ExecuteTest/ExecuteTest.ts
@@ -1,7 +1,7 @@
-import { RendererWorker } from '@lvce-editor/rpc-registry'
 import * as AutoFixState from '../AutoFixState/AutoFixState.ts'
 import { executeTest2 } from '../ExecuteTest2/ExecuteTest2.ts'
 import { printTestError } from '../PrintTestError/PrintTestError.ts'
+import * as RendererProcess from '../RendererProcess/RendererProcess.ts'
 import * as Timestamp from '../Timestamp/Timestamp.ts'
 
 export const executeTest = async (name: string, fn: any, globals = {}): Promise<void> => {
@@ -15,8 +15,8 @@ export const executeTest = async (name: string, fn: any, globals = {}): Promise<
   }
 
   if (overlayActions && overlayActions.length > 0) {
-    await RendererWorker.invoke('TestFrameWork.showOverlay', type, background, text, overlayActions)
+    await RendererProcess.invoke('TestFrameWork.showOverlay', type, background, text, overlayActions)
     return
   }
-  await RendererWorker.invoke('TestFrameWork.showOverlay', type, background, text)
+  await RendererProcess.invoke('TestFrameWork.showOverlay', type, background, text)
 }

--- a/packages/test-worker/src/parts/GetLocatorInvoke/GetLocatorInvoke.ts
+++ b/packages/test-worker/src/parts/GetLocatorInvoke/GetLocatorInvoke.ts
@@ -1,5 +1,5 @@
-import { RendererWorker } from '@lvce-editor/rpc-registry'
 import type { ILocator } from '../ILocator/ILocator.ts'
+import * as RendererProcess from '../RendererProcess/RendererProcess.ts'
 import * as WebViewState from '../WebViewState/WebViewState.ts'
 
 interface Invoke {
@@ -14,5 +14,5 @@ export const getLocatorInvoke = (locator: ILocator): Invoke => {
     return module.invoke
   }
 
-  return RendererWorker.invoke
+  return RendererProcess.invoke
 }

--- a/packages/test-worker/src/parts/RendererProcess/RendererProcess.ts
+++ b/packages/test-worker/src/parts/RendererProcess/RendererProcess.ts
@@ -1,0 +1,20 @@
+import { PlainMessagePortRpcParent, type Rpc } from '@lvce-editor/rpc'
+import { RendererWorker } from '@lvce-editor/rpc-registry'
+
+export const state: { rpc: Rpc | undefined } = {
+  rpc: undefined,
+}
+
+export const initialize = async (port: MessagePort): Promise<void> => {
+  state.rpc = await PlainMessagePortRpcParent.create({
+    commandMap: {},
+    messagePort: port,
+  })
+}
+
+export const invoke = (method: string, ...params: readonly any[]): Promise<any> => {
+  if (state.rpc) {
+    return state.rpc.invoke(method, ...params)
+  }
+  return RendererWorker.invoke(method, ...params)
+}

--- a/packages/test-worker/src/parts/Test/Test.ts
+++ b/packages/test-worker/src/parts/Test/Test.ts
@@ -7,6 +7,7 @@ import { formatDuration } from '../FormatDuration/FormatDuration.ts'
 import { hotReloadEnabled } from '../HotReloadEnabled/HotReloadEnabled.ts'
 import * as ImportTest from '../ImportTest/ImportTest.ts'
 import { printTestError } from '../PrintTestError/PrintTestError.ts'
+import * as RendererProcess from '../RendererProcess/RendererProcess.ts'
 import { roundTestResults } from '../RoundTestResults/RoundTestResults.ts'
 import * as ShouldSkipTest from '../ShouldSkipTest/ShouldSkipTest.ts'
 import * as TestFrameWork from '../TestFrameWork/TestFrameWork.ts'
@@ -149,7 +150,7 @@ const showAllTestsOverlay = async (results: readonly ExecuteAllTestResult[], dur
     background = 'red'
   }
   const text = `${getSummaryParts(results).join(', ')} in ${formatDuration(duration)}`
-  await RendererWorker.invoke('TestFrameWork.showOverlay', type, background, text)
+  await RendererProcess.invoke('TestFrameWork.showOverlay', type, background, text)
 }
 
 // TODO move this into three steps:
@@ -187,7 +188,7 @@ export const execute = async (href: string, platform: number, assetDir: string):
   } catch (error) {
     AutoFixState.clear()
     await printTestError(error)
-    await RendererWorker.invoke('TestFrameWork.showOverlay', TestType.Fail, 'red', `test failed: ${error}`)
+    await RendererProcess.invoke('TestFrameWork.showOverlay', TestType.Fail, 'red', `test failed: ${error}`)
     return
   } finally {
     TestInfoCache.push({
@@ -224,7 +225,7 @@ export const executeAll = async (tests: readonly ExecuteAllTest[], href: string,
   }
   const end = Timestamp.now()
   await showAllTestsOverlay(results, end - start)
-  await RendererWorker.invoke('TestFrameWork.showTestResults', JSON.stringify(roundTestResults(results)))
+  await RendererProcess.invoke('TestFrameWork.showTestResults', JSON.stringify(roundTestResults(results)))
   TestInfoCache.push({
     assetDir,
     inProgress: false,

--- a/packages/test-worker/src/parts/TestFrameWork/TestFrameWork.ts
+++ b/packages/test-worker/src/parts/TestFrameWork/TestFrameWork.ts
@@ -1,6 +1,6 @@
-import { RendererWorker } from '@lvce-editor/rpc-registry'
 import * as Expect from '../Expect/Expect.ts'
 import * as NameAnonymousFunction from '../NameAnonymousFunction/NameAnonymousFunction.ts'
+import * as RendererProcess from '../RendererProcess/RendererProcess.ts'
 import * as TestState from '../TestState/TestState.ts'
 
 export { createLocator as Locator } from '../CreateLocator/CreateLocator.ts'
@@ -19,7 +19,7 @@ export const skipTest = async (id: string): Promise<void> => {
   const background = 'yellow'
   const text = `test skipped ${id}`
 
-  await RendererWorker.invoke('TestFrameWork.showOverlay', state, background, text)
+  await RendererProcess.invoke('TestFrameWork.showOverlay', state, background, text)
 }
 
 export const { expect } = Expect

--- a/packages/test-worker/src/parts/TestFrameWorkComponentKeyBoard/TestFrameWorkComponentKeyBoard.ts
+++ b/packages/test-worker/src/parts/TestFrameWorkComponentKeyBoard/TestFrameWorkComponentKeyBoard.ts
@@ -1,5 +1,5 @@
-import { RendererWorker } from '@lvce-editor/rpc-registry'
 import * as GetKeyOptions from '../GetKeyOptions/GetKeyOptions.ts'
+import * as RendererProcess from '../RendererProcess/RendererProcess.ts'
 
 export const press = async (key: string): Promise<void> => {
   const keyOptions = GetKeyOptions.getKeyOptions(key)
@@ -9,5 +9,5 @@ export const press = async (key: string): Promise<void> => {
     ...keyOptions,
   }
 
-  await RendererWorker.invoke('TestFrameWork.performKeyBoardAction', 'press', options)
+  await RendererProcess.invoke('TestFrameWork.performKeyBoardAction', 'press', options)
 }

--- a/packages/test-worker/test/GetLocatorInvoke.test.ts
+++ b/packages/test-worker/test/GetLocatorInvoke.test.ts
@@ -1,6 +1,6 @@
 import { expect, test } from '@jest/globals'
-import { RendererWorker } from '@lvce-editor/rpc-registry'
 import * as GetLocatorInvoke from '../src/parts/GetLocatorInvoke/GetLocatorInvoke.ts'
+import * as RendererProcess from '../src/parts/RendererProcess/RendererProcess.ts'
 import * as WebViewState from '../src/parts/WebViewState/WebViewState.ts'
 
 const invoke: () => void = (): void => {}
@@ -12,9 +12,9 @@ test('getLocatorInvoke: webView locator', (): void => {
   expect(result).toBe(invoke)
 })
 
-test('getLocatorInvoke: default to RendererWorker', (): void => {
+test('getLocatorInvoke: default to RendererProcess', (): void => {
   const locator: any = {}
   const result: any = GetLocatorInvoke.getLocatorInvoke(locator)
 
-  expect(result).toBe(RendererWorker.invoke)
+  expect(result).toBe(RendererProcess.invoke)
 })

--- a/packages/test-worker/test/RendererProcess.test.ts
+++ b/packages/test-worker/test/RendererProcess.test.ts
@@ -1,0 +1,58 @@
+import type { Rpc } from '@lvce-editor/rpc'
+import { afterEach, expect, jest, test } from '@jest/globals'
+import { RendererWorker } from '@lvce-editor/rpc-registry'
+
+const directInvoke = jest.fn<(...params: readonly any[]) => Promise<any>>()
+const directRpc = {
+  invoke: directInvoke,
+} as unknown as Rpc
+const create = jest.fn<(_options: any) => Promise<Rpc>>(async () => directRpc)
+
+jest.unstable_mockModule('@lvce-editor/rpc', () => ({
+  PlainMessagePortRpcParent: {
+    create,
+  },
+}))
+
+const RendererProcess = await import('../src/parts/RendererProcess/RendererProcess.ts')
+
+afterEach(() => {
+  RendererProcess.state.rpc = undefined
+  create.mockClear()
+  directInvoke.mockReset()
+})
+
+test('initialize creates a direct message port rpc', async () => {
+  const port = {} as MessagePort
+
+  await RendererProcess.initialize(port)
+
+  expect(create).toHaveBeenCalledTimes(1)
+  expect(create).toHaveBeenCalledWith({
+    commandMap: {},
+    messagePort: port,
+  })
+  expect(RendererProcess.state.rpc).toBe(directRpc)
+})
+
+test('invoke uses the direct renderer process rpc when initialized', async () => {
+  directInvoke.mockResolvedValue({ error: false })
+  RendererProcess.state.rpc = directRpc
+
+  await expect(RendererProcess.invoke('TestFrameWork.checkSingleElementCondition', { selector: '.Editor' })).resolves.toEqual({ error: false })
+
+  expect(directInvoke).toHaveBeenCalledTimes(1)
+  expect(directInvoke).toHaveBeenCalledWith('TestFrameWork.checkSingleElementCondition', { selector: '.Editor' })
+})
+
+test('invoke falls back to the renderer worker before initialization', async () => {
+  using mockRpc = RendererWorker.registerMockRpc({
+    'TestFrameWork.showOverlay'() {
+      return undefined
+    },
+  })
+
+  await RendererProcess.invoke('TestFrameWork.showOverlay', 'pass', 'green', 'passed')
+
+  expect(mockRpc.invocations).toEqual([['TestFrameWork.showOverlay', 'pass', 'green', 'passed']])
+})


### PR DESCRIPTION
Routes renderer-local test framework checks, actions, keyboard input, overlays, and results through a dedicated renderer-process RPC, while retaining the renderer-worker fallback until the direct port is initialized.