### PR TITLE
feature: compact test condition locator payloads

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2678,9 +2678,9 @@
       "license": "MIT"
     },
     "node_modules/@lvce-editor/auth-process": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/auth-process/-/auth-process-1.9.0.tgz",
-      "integrity": "sha512-ISmJm47TYZ/WqOWp+8CFVD8CQXVkzuu18L8qiT50sjqtMPfOg9zQ6DWehAWZcDtCP//GYavMlpz0KkJIXcuCMw==",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/auth-process/-/auth-process-1.10.0.tgz",
+      "integrity": "sha512-GlyU+4vJG88eSRsp9rjcj/ZDGRKR8oYKFAKB7pKA8ovSz9OlS14ddnqlaS5uZ6zpD2u5D6iS2eO78AeSvAaiBg==",
       "license": "MIT",
       "bin": {
         "auth-process": "bin/oauthProcess.js"
@@ -2702,9 +2702,9 @@
       "license": "MIT"
     },
     "node_modules/@lvce-editor/embeds-process": {
-      "version": "4.9.1",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/embeds-process/-/embeds-process-4.9.1.tgz",
-      "integrity": "sha512-YkwhW4R48MA2kXlxxIBNWMTTYg1FZlUT4bjJSCeUENLYbltv2KWXgdWF8Giysys/V0RzX6zbJqkdOiiO6qyJLQ==",
+      "version": "4.10.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/embeds-process/-/embeds-process-4.10.0.tgz",
+      "integrity": "sha512-mEKsVl6i/Qd/YQuFvzr6806pg6YIq0vo9AQ1v42U7ir+7sD3y3fvUcEL7yyOrC2+CimeoByj8BTEHHMFJNuB2w==",
       "license": "MIT",
       "optional": true,
       "bin": {
@@ -2831,9 +2831,9 @@
       "license": "MIT"
     },
     "node_modules/@lvce-editor/extension-host-helper-process": {
-      "version": "0.91.3",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/extension-host-helper-process/-/extension-host-helper-process-0.91.3.tgz",
-      "integrity": "sha512-sYD7aOpXS80pKyStZu0rYKlZ/yT0AziNeX4IPBKkcfOBcziOQsN6pVdFGQHiYem5ZtEOW5aRSaQ/K0eymzepOA==",
+      "version": "0.91.30",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/extension-host-helper-process/-/extension-host-helper-process-0.91.30.tgz",
+      "integrity": "sha512-lUctrfYGAZItR5cEwklRXIG59XYdsxtGzY6BCVR/7rdMkb9afLZOKJk9y0Ad5lWyb7HXHunp8vgyEwpwOaoLbQ==",
       "license": "MIT",
       "dependencies": {
         "@lvce-editor/assert": "^1.7.0",
@@ -2848,9 +2848,9 @@
       }
     },
     "node_modules/@lvce-editor/file-system-process": {
-      "version": "5.4.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/file-system-process/-/file-system-process-5.4.0.tgz",
-      "integrity": "sha512-QeaqkR61uMQFiV7S182isrn8XhaA1o6TyU7liGM7gZMJmmK4nma9vneeqC2yJFxNP+nJws8sMq/B+z53qEADEg==",
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/file-system-process/-/file-system-process-5.5.1.tgz",
+      "integrity": "sha512-kmVihRCa4LpcgwC4KN+jtdYuAAn+2UWfjtBaAZmuDLVqElQnn+lExWvjQoD3U2dOble9WU9/Y8uX5ejRI4mJEQ==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -2865,9 +2865,9 @@
       }
     },
     "node_modules/@lvce-editor/file-watcher-process": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/file-watcher-process/-/file-watcher-process-4.5.0.tgz",
-      "integrity": "sha512-xSVa5AWblaRcVLxsxuQr1diGrQY2RWXFXTUvwg5sio1eHtKOqoDZi+FR92RSMKypIUDDCuH8JsU9OsoeW9W65g==",
+      "version": "4.6.3",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/file-watcher-process/-/file-watcher-process-4.6.3.tgz",
+      "integrity": "sha512-Kjxgiv4HfJ3tDVicgfjzpBQLxZtUs4N5AjcSui3sl9pxvoW6kYhv13BakIaBXlvxpOsHSsbKITRwkCtmu0cJ+g==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -3279,9 +3279,9 @@
       }
     },
     "node_modules/@lvce-editor/rpc-registry": {
-      "version": "9.35.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/rpc-registry/-/rpc-registry-9.35.0.tgz",
-      "integrity": "sha512-ZdY4vLJ1RLCacxACY0AJ1nGQgHyZBLUmbuq5TuI0zzqaKXJh5f/SLEWRWUsnXtlSMg0hS/1uzLKKga3gO8svNg==",
+      "version": "9.36.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/rpc-registry/-/rpc-registry-9.36.0.tgz",
+      "integrity": "sha512-fbV4xYg0jZn06TcicEOm0wM+kA23OXZk+NK3QZsjNCIBdl0Pv6+V0GiR1aAbU+wlMmbLuHkEpmtSXfoBKrbGBw==",
       "license": "MIT",
       "dependencies": {
         "@lvce-editor/assert": "^1.5.1",
@@ -3311,13 +3311,13 @@
       }
     },
     "node_modules/@lvce-editor/server": {
-      "version": "0.91.3",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/server/-/server-0.91.3.tgz",
-      "integrity": "sha512-suwzex/+z/ARr500fKOMezqwN1bXah14P1uks2tNGBInvGkIPsy7jS8DBY2BeZFlsLg/yQvFWzBrUlP3EULfbw==",
+      "version": "0.91.30",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/server/-/server-0.91.30.tgz",
+      "integrity": "sha512-6pV4fkDl8NX+v/mewLzKz5Gr73mIz0MjllbRh0BmRghHkeUb0zCpI32qayMCXEAtu1p+PbRhl74hx7fV/4b6zw==",
       "license": "MIT",
       "dependencies": {
-        "@lvce-editor/shared-process": "0.91.3",
-        "@lvce-editor/static-server": "0.91.3"
+        "@lvce-editor/shared-process": "0.91.30",
+        "@lvce-editor/static-server": "0.91.30"
       },
       "bin": {
         "server": "bin/server.js"
@@ -3327,20 +3327,20 @@
       }
     },
     "node_modules/@lvce-editor/shared-process": {
-      "version": "0.91.3",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/shared-process/-/shared-process-0.91.3.tgz",
-      "integrity": "sha512-tNbg1tvO9vAOy7XGAhk46T2tflczsK0v7YmQEp7UI+Ym5kR1S2bMqkynVY2qGaDcxinSRoRuBxAXKny7tV4Hew==",
+      "version": "0.91.30",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/shared-process/-/shared-process-0.91.30.tgz",
+      "integrity": "sha512-qZM1uFjFn00tDo2ExsDvsH0G1c4YtksA/5eROM3vbUBAZEvMKK1aNTK/qhxiniObsC04bjcGYgSw6isY8xuh4g==",
       "license": "MIT",
       "dependencies": {
         "@lvce-editor/assert": "1.7.0",
-        "@lvce-editor/auth-process": "1.9.0",
-        "@lvce-editor/extension-host-helper-process": "0.91.3",
-        "@lvce-editor/ipc": "16.3.0",
-        "@lvce-editor/json-rpc": "8.2.0",
+        "@lvce-editor/auth-process": "1.10.0",
+        "@lvce-editor/extension-host-helper-process": "0.91.30",
+        "@lvce-editor/ipc": "16.4.0",
+        "@lvce-editor/json-rpc": "8.3.0",
         "@lvce-editor/jsonc-parser": "1.5.0",
         "@lvce-editor/pretty-error": "2.0.0",
         "@lvce-editor/process-explorer": "3.10.0",
-        "@lvce-editor/rpc-registry": "9.35.0",
+        "@lvce-editor/rpc-registry": "9.36.0",
         "@lvce-editor/verror": "1.7.0",
         "is-object": "^1.0.2",
         "markdown-it": "^14.3.0",
@@ -3350,45 +3350,25 @@
         "node": ">=24"
       },
       "optionalDependencies": {
-        "@lvce-editor/embeds-process": "4.9.1",
-        "@lvce-editor/file-system-process": "5.4.0",
-        "@lvce-editor/file-watcher-process": "4.5.0",
+        "@lvce-editor/embeds-process": "4.10.0",
+        "@lvce-editor/file-system-process": "5.5.1",
+        "@lvce-editor/file-watcher-process": "4.6.3",
         "@lvce-editor/network-process": "5.2.0",
         "@lvce-editor/preload": "1.5.0",
         "@lvce-editor/preview-process": "11.0.0",
         "@lvce-editor/pty-host": "8.3.0",
         "@lvce-editor/search-process": "15.1.0",
-        "@lvce-editor/typescript-compile-process": "5.3.0",
+        "@lvce-editor/typescript-compile-process": "5.4.0",
         "open": "^11.0.0",
         "tail": "^2.2.6",
         "tmp-promise": "^3.0.3",
         "trash": "^10.1.1"
       }
     },
-    "node_modules/@lvce-editor/shared-process/node_modules/@lvce-editor/ipc": {
-      "version": "16.3.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/ipc/-/ipc-16.3.0.tgz",
-      "integrity": "sha512-Hf5for20Z0qIcS/6dh2t8vHlEQiKuIzOr0avCoMl+Mltl+Wsb2ybwknvSDyYanx0BdS/3Jqrvm2oyHqMbs+u2g==",
-      "license": "MIT",
-      "dependencies": {
-        "@lvce-editor/assert": "^1.5.1",
-        "@lvce-editor/verror": "^1.7.0",
-        "@lvce-editor/web-socket-server": "^2.1.0"
-      },
-      "engines": {
-        "node": ">=22"
-      }
-    },
-    "node_modules/@lvce-editor/shared-process/node_modules/@lvce-editor/json-rpc": {
-      "version": "8.2.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/json-rpc/-/json-rpc-8.2.0.tgz",
-      "integrity": "sha512-iBpaJzkMkJWrg7dr4rQPnb/YEBwZ9l62USAP9TEu280cPi7DfxvrxsthzRgOZNVh6Eg+AHM0Tq7lsxMIKVsfkQ==",
-      "license": "MIT"
-    },
     "node_modules/@lvce-editor/static-server": {
-      "version": "0.91.3",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/static-server/-/static-server-0.91.3.tgz",
-      "integrity": "sha512-rCfA0jGuQ+owjbQJyyGcM7NyBUZu9XV3FxcTsVU0AwWZLYEBd7zo2mfD4dFIN/OQlD4Ao3q2m2G8s1dd7IUp3g==",
+      "version": "0.91.30",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/static-server/-/static-server-0.91.30.tgz",
+      "integrity": "sha512-AE3QwsqYmlIwl1wmYh1BurZRloTQo4cuVwNNDQAHSswhVdXqJGUOSE5JLF88idYyw98B6ej/LXwuHp2bvDLElg==",
       "license": "MIT",
       "engines": {
         "node": ">=24"
@@ -3449,9 +3429,9 @@
       "link": true
     },
     "node_modules/@lvce-editor/typescript-compile-process": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/typescript-compile-process/-/typescript-compile-process-5.3.0.tgz",
-      "integrity": "sha512-0NlQK1Ck/Xanq8tcw+v9zlHc576EFFZ0jwxr8BWN5SY0c/G1f6gU8pirJBkW5mz2A1GfV9aj67P+NDk1iLUChg==",
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/typescript-compile-process/-/typescript-compile-process-5.4.0.tgz",
+      "integrity": "sha512-nBHfHtqiWTMDJpdsq3xju/RdL8LLH/rsUzcda0y0wbSlmG0PmCOvNIN3LA+FfLX+FpHtDk41JRc7TGZ0vW971Q==",
       "license": "MIT",
       "optional": true,
       "bin": {
@@ -15706,7 +15686,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@lvce-editor/server": "^0.91.3"
+        "@lvce-editor/server": "^0.91.30"
       }
     },
     "packages/test-worker": {

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -11,6 +11,6 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
-    "@lvce-editor/server": "^0.91.3"
+    "@lvce-editor/server": "^0.91.30"
   }
 }

--- a/packages/test-worker/src/parts/ConditionErrors/ConditionErrors.ts
+++ b/packages/test-worker/src/parts/ConditionErrors/ConditionErrors.ts
@@ -1,4 +1,5 @@
 import type { ILocatorInternal } from '../ILocatorInternal/ILocatorInternal.ts'
+import * as GetConditionLocator from '../GetConditionLocator/GetConditionLocator.ts'
 import { locatorInvoke } from '../LocatorInvoke/LocatorInvoke.ts'
 import { printLocator } from '../PrintLocator/PrintLocator.ts'
 
@@ -19,7 +20,8 @@ export const toHaveValue = (
 
 export const toHaveText = async (locator: ILocatorInternal, options: { readonly text: string }): Promise<string> => {
   const locatorString = printLocator(locator)
-  const { actual, wasFound } = await locatorInvoke(locator, 'TestFrameWork.checkConditionError', 'toHaveText', locator, options)
+  const conditionLocator = GetConditionLocator.getConditionLocator(locator)
+  const { actual, wasFound } = await locatorInvoke(locator, 'TestFrameWork.checkConditionError', 'toHaveText', conditionLocator, options)
   const { text } = options
   if (!wasFound) {
     return `expected selector ${locatorString} to have text "${text}" element was not found`
@@ -29,7 +31,8 @@ export const toHaveText = async (locator: ILocatorInternal, options: { readonly 
 
 export const toContainText = async (locator: ILocatorInternal, options: { readonly text: string }): Promise<string> => {
   const locatorString = printLocator(locator)
-  const { actual, wasFound } = await locatorInvoke(locator, 'TestFrameWork.checkConditionError', 'toContainText', locator, options)
+  const conditionLocator = GetConditionLocator.getConditionLocator(locator)
+  const { actual, wasFound } = await locatorInvoke(locator, 'TestFrameWork.checkConditionError', 'toContainText', conditionLocator, options)
   const { text } = options
   if (!wasFound) {
     return `expected selector ${locatorString} to contain text "${text}" element was not found`
@@ -45,7 +48,8 @@ export const toHaveAttribute = async (
   },
 ): Promise<string> => {
   const locatorString = printLocator(locator)
-  const { actual, wasFound } = await locatorInvoke(locator, 'TestFrameWork.checkConditionError', 'toHaveAttribute', locator, options)
+  const conditionLocator = GetConditionLocator.getConditionLocator(locator)
+  const { actual, wasFound } = await locatorInvoke(locator, 'TestFrameWork.checkConditionError', 'toHaveAttribute', conditionLocator, options)
   const { key, value } = options
   if (!wasFound) {
     return `expected ${locatorString} to have attribute ${key} ${value} but element was not found`
@@ -62,13 +66,15 @@ export const toHaveCount = async (
   },
 ): Promise<string> => {
   const locatorString = printLocator(locator)
-  const { actual } = await locatorInvoke(locator, 'TestFrameWork.checkConditionError', 'toHaveCount', locator)
+  const conditionLocator = GetConditionLocator.getConditionLocator(locator)
+  const { actual } = await locatorInvoke(locator, 'TestFrameWork.checkConditionError', 'toHaveCount', conditionLocator)
   return `expected ${locatorString} to have count ${count} but was ${actual}`
 }
 
 export const toBeFocused = async (locator: ILocatorInternal): Promise<string> => {
   const locatorString = printLocator(locator)
-  const { actual } = await locatorInvoke(locator, 'TestFrameWork.checkConditionError', 'toBeFocused', locator)
+  const conditionLocator = GetConditionLocator.getConditionLocator(locator)
+  const { actual } = await locatorInvoke(locator, 'TestFrameWork.checkConditionError', 'toBeFocused', conditionLocator)
   return `expected ${locatorString} to be focused but active element is ${actual}`
 }
 
@@ -79,7 +85,8 @@ export const toHaveClass = async (
   },
 ): Promise<string> => {
   const locatorString = printLocator(locator)
-  const { wasFound } = await locatorInvoke(locator, 'TestFrameWork.checkConditionError', 'toHaveClass', locator, options)
+  const conditionLocator = GetConditionLocator.getConditionLocator(locator)
+  const { wasFound } = await locatorInvoke(locator, 'TestFrameWork.checkConditionError', 'toHaveClass', conditionLocator, options)
   const { className } = options
   if (!wasFound) {
     return `expected ${locatorString} to have class ${className} but element was not found`
@@ -93,7 +100,8 @@ export const toHaveId = async (
     readonly id: string
   },
 ): Promise<string> => {
-  const { actual, wasFound } = await locatorInvoke(locator, 'TestFrameWork.checkConditionError', 'toHaveId', locator, options)
+  const conditionLocator = GetConditionLocator.getConditionLocator(locator)
+  const { actual, wasFound } = await locatorInvoke(locator, 'TestFrameWork.checkConditionError', 'toHaveId', conditionLocator, options)
   const locatorString = printLocator(locator)
   const { id } = options
   if (!wasFound) {
@@ -114,7 +122,8 @@ export const toHaveCss = async (
     readonly value: string
   },
 ): Promise<string> => {
-  const { actual, wasFound } = await locatorInvoke(locator, 'TestFrameWork.checkConditionError', 'toHaveCss', locator, options)
+  const conditionLocator = GetConditionLocator.getConditionLocator(locator)
+  const { actual, wasFound } = await locatorInvoke(locator, 'TestFrameWork.checkConditionError', 'toHaveCss', conditionLocator, options)
   const locatorString = printLocator(locator)
   const { key, value } = options
   if (!wasFound) {
@@ -130,7 +139,8 @@ export const toHaveJSProperty = async (
     readonly value: string
   },
 ): Promise<string> => {
-  const { actual, wasFound } = await locatorInvoke(locator, 'TestFrameWork.checkConditionError', 'toHaveJSProperty', locator, options)
+  const conditionLocator = GetConditionLocator.getConditionLocator(locator)
+  const { actual, wasFound } = await locatorInvoke(locator, 'TestFrameWork.checkConditionError', 'toHaveJSProperty', conditionLocator, options)
   const locatorString = printLocator(locator)
   const { key, value } = options
   if (!wasFound) {

--- a/packages/test-worker/src/parts/Expect/Expect.ts
+++ b/packages/test-worker/src/parts/Expect/Expect.ts
@@ -1,7 +1,9 @@
+import type { ILocator } from '../ILocator/ILocator.ts'
 import type { ILocatorExternal } from '../ILocatorExternal/ILocatorExternal.ts'
 import type { LocatorExpect } from '../LocatorExpect/LocatorExpect.ts'
 import { AssertionError } from '../AssertionError/AssertionError.ts'
 import * as ConditionErrorMap from '../ConditionErrorMap/ConditionErrorMap.ts'
+import * as GetConditionLocator from '../GetConditionLocator/GetConditionLocator.ts'
 import * as LocatorInvoke from '../LocatorInvoke/LocatorInvoke.ts'
 import * as Assert from '../TestAssert/TestAssert.ts'
 
@@ -11,16 +13,17 @@ export const expect = (locator: ILocatorExternal): LocatorExpect => {
 
 class Expect {
   readonly negated: boolean = false
-  readonly locator: ILocatorExternal
+  readonly locator: ILocator
 
   constructor(locator: ILocatorExternal, negated: boolean = false) {
-    this.locator = locator
+    this.locator = locator as ILocator
     this.negated = negated
   }
 
   async checkSingleElementCondition(fnName: string, options?: any): Promise<void> {
     // TODO add rpcId property to locator instead
-    const result = await LocatorInvoke.locatorInvoke(this.locator, 'TestFrameWork.checkSingleElementCondition', this.locator, fnName, options)
+    const conditionLocator = GetConditionLocator.getConditionLocator(this.locator)
+    const result = await LocatorInvoke.locatorInvoke(this.locator, 'TestFrameWork.checkSingleElementCondition', conditionLocator, fnName, options)
     if (result && result.error) {
       const fn = ConditionErrorMap.getFunction(fnName)
       const errorInfo = await fn(this.locator, options)
@@ -28,7 +31,8 @@ class Expect {
     }
   }
   async checkMultiElementCondition(fnName: string, options: any): Promise<void> {
-    const result = await LocatorInvoke.locatorInvoke(this.locator, 'TestFrameWork.checkMultiElementCondition', this.locator, fnName, options)
+    const conditionLocator = GetConditionLocator.getConditionLocator(this.locator)
+    const result = await LocatorInvoke.locatorInvoke(this.locator, 'TestFrameWork.checkMultiElementCondition', conditionLocator, fnName, options)
     if (result && result.error) {
       const fn = ConditionErrorMap.getFunction(fnName)
       const errorInfo = await fn(this.locator, options)

--- a/packages/test-worker/src/parts/GetConditionLocator/GetConditionLocator.ts
+++ b/packages/test-worker/src/parts/GetConditionLocator/GetConditionLocator.ts
@@ -1,0 +1,15 @@
+import type { ILocatorInternal } from '../ILocatorInternal/ILocatorInternal.ts'
+import type { ParsedCssSelector } from '../ParseCssSelector/ParseCssSelector.ts'
+
+interface WebViewLocator extends ILocatorInternal {
+  readonly webViewId: string
+}
+
+export type ConditionLocator = ILocatorInternal | ParsedCssSelector
+
+export const getConditionLocator = (locator: ILocatorInternal): ConditionLocator => {
+  if ('webViewId' in locator && typeof (locator as WebViewLocator).webViewId === 'string') {
+    return locator
+  }
+  return locator._parsed
+}

--- a/packages/test-worker/test/ConditionErrors.test.ts
+++ b/packages/test-worker/test/ConditionErrors.test.ts
@@ -49,7 +49,7 @@ test('toHaveText - element not found', async () => {
   })
   const result = await ConditionErrors.toHaveText(locator, { text: 'hello' })
   expect(result).toBe('expected selector .text to have text "hello" element was not found')
-  expect(mockRpc.invocations).toEqual([['TestFrameWork.checkConditionError', 'toHaveText', locator, { text: 'hello' }]])
+  expect(mockRpc.invocations).toEqual([['TestFrameWork.checkConditionError', 'toHaveText', locator._parsed, { text: 'hello' }]])
 })
 
 test('toHaveText - wrong text', async () => {
@@ -61,7 +61,7 @@ test('toHaveText - wrong text', async () => {
   })
   const result = await ConditionErrors.toHaveText(locator, { text: 'hello' })
   expect(result).toBe('expected selector .text to have text "hello" but was "world"')
-  expect(mockRpc.invocations).toEqual([['TestFrameWork.checkConditionError', 'toHaveText', locator, { text: 'hello' }]])
+  expect(mockRpc.invocations).toEqual([['TestFrameWork.checkConditionError', 'toHaveText', locator._parsed, { text: 'hello' }]])
 })
 
 test('toHaveText - with hasText selector', async () => {
@@ -73,7 +73,7 @@ test('toHaveText - with hasText selector', async () => {
   })
   const result = await ConditionErrors.toHaveText(locator, { text: 'test' })
   expect(result).toBe('expected selector .item "hello" to have text "test" but was "wrong"')
-  expect(mockRpc.invocations).toEqual([['TestFrameWork.checkConditionError', 'toHaveText', locator, { text: 'test' }]])
+  expect(mockRpc.invocations).toEqual([['TestFrameWork.checkConditionError', 'toHaveText', locator._parsed, { text: 'test' }]])
 })
 
 test('toHaveAttribute - element not found', async () => {
@@ -89,7 +89,7 @@ test('toHaveAttribute - element not found', async () => {
     [
       'TestFrameWork.checkConditionError',
       'toHaveAttribute',
-      locator,
+      locator._parsed,
       {
         key: 'href',
         value: '#',
@@ -111,7 +111,7 @@ test('toHaveAttribute - wrong value', async () => {
     [
       'TestFrameWork.checkConditionError',
       'toHaveAttribute',
-      locator,
+      locator._parsed,
       {
         key: 'href',
         value: '#',
@@ -129,7 +129,7 @@ test('toHaveCount', async () => {
   })
   const result = await ConditionErrors.toHaveCount(locator, { count: 3 })
   expect(result).toBe('expected .items to have count 3 but was 1')
-  expect(mockRpc.invocations).toEqual([['TestFrameWork.checkConditionError', 'toHaveCount', locator]])
+  expect(mockRpc.invocations).toEqual([['TestFrameWork.checkConditionError', 'toHaveCount', locator._parsed]])
 })
 
 test('toBeFocused', async () => {
@@ -141,7 +141,7 @@ test('toBeFocused', async () => {
   })
   const result = await ConditionErrors.toBeFocused(locator)
   expect(result).toBe('expected .input to be focused but active element is BUTTON')
-  expect(mockRpc.invocations).toEqual([['TestFrameWork.checkConditionError', 'toBeFocused', locator]])
+  expect(mockRpc.invocations).toEqual([['TestFrameWork.checkConditionError', 'toBeFocused', locator._parsed]])
 })
 
 test('toBeFocused - with document.body', async () => {
@@ -153,7 +153,7 @@ test('toBeFocused - with document.body', async () => {
   })
   const result = await ConditionErrors.toBeFocused(locator)
   expect(result).toBe('expected .input to be focused but active element is document.body')
-  expect(mockRpc.invocations).toEqual([['TestFrameWork.checkConditionError', 'toBeFocused', locator]])
+  expect(mockRpc.invocations).toEqual([['TestFrameWork.checkConditionError', 'toBeFocused', locator._parsed]])
 })
 
 test('toBeHidden', () => {
@@ -170,7 +170,7 @@ test('toHaveClass - element not found', async () => {
   })
   const result = await ConditionErrors.toHaveClass(locator, { className: 'active' })
   expect(result).toBe('expected .button to have class active but element was not found')
-  expect(mockRpc.invocations).toEqual([['TestFrameWork.checkConditionError', 'toHaveClass', locator, { className: 'active' }]])
+  expect(mockRpc.invocations).toEqual([['TestFrameWork.checkConditionError', 'toHaveClass', locator._parsed, { className: 'active' }]])
 })
 
 test('toHaveClass - wrong class', async () => {
@@ -182,7 +182,7 @@ test('toHaveClass - wrong class', async () => {
   })
   const result = await ConditionErrors.toHaveClass(locator, { className: 'active' })
   expect(result).toBe('expected .button to have class active')
-  expect(mockRpc.invocations).toEqual([['TestFrameWork.checkConditionError', 'toHaveClass', locator, { className: 'active' }]])
+  expect(mockRpc.invocations).toEqual([['TestFrameWork.checkConditionError', 'toHaveClass', locator._parsed, { className: 'active' }]])
 })
 
 test('toHaveId - element not found', async () => {
@@ -194,7 +194,7 @@ test('toHaveId - element not found', async () => {
   })
   const result = await ConditionErrors.toHaveId(locator, { id: 'submit' })
   expect(result).toBe('expected .button to have id submit but element was not found')
-  expect(mockRpc.invocations).toEqual([['TestFrameWork.checkConditionError', 'toHaveId', locator, { id: 'submit' }]])
+  expect(mockRpc.invocations).toEqual([['TestFrameWork.checkConditionError', 'toHaveId', locator._parsed, { id: 'submit' }]])
 })
 
 test('toHaveId - wrong id', async () => {
@@ -206,7 +206,7 @@ test('toHaveId - wrong id', async () => {
   })
   const result = await ConditionErrors.toHaveId(locator, { id: 'submit' })
   expect(result).toBe('expected .button to have id submit but was cancel')
-  expect(mockRpc.invocations).toEqual([['TestFrameWork.checkConditionError', 'toHaveId', locator, { id: 'submit' }]])
+  expect(mockRpc.invocations).toEqual([['TestFrameWork.checkConditionError', 'toHaveId', locator._parsed, { id: 'submit' }]])
 })
 
 test('toHaveCss - element not found', async () => {
@@ -222,7 +222,7 @@ test('toHaveCss - element not found', async () => {
     [
       'TestFrameWork.checkConditionError',
       'toHaveCss',
-      locator,
+      locator._parsed,
       {
         key: 'display',
         value: 'flex',
@@ -244,7 +244,7 @@ test('toHaveCss - wrong value', async () => {
     [
       'TestFrameWork.checkConditionError',
       'toHaveCss',
-      locator,
+      locator._parsed,
       {
         key: 'display',
         value: 'flex',
@@ -262,7 +262,7 @@ test('toContainText - element not found', async () => {
   })
   const result = await ConditionErrors.toContainText(locator, { text: 'hello' })
   expect(result).toBe('expected selector .text to contain text "hello" element was not found')
-  expect(mockRpc.invocations).toEqual([['TestFrameWork.checkConditionError', 'toContainText', locator, { text: 'hello' }]])
+  expect(mockRpc.invocations).toEqual([['TestFrameWork.checkConditionError', 'toContainText', locator._parsed, { text: 'hello' }]])
 })
 
 test('toContainText - wrong text', async () => {
@@ -274,7 +274,7 @@ test('toContainText - wrong text', async () => {
   })
   const result = await ConditionErrors.toContainText(locator, { text: 'hello' })
   expect(result).toBe('expected selector .text to contain text "hello" but was "world"')
-  expect(mockRpc.invocations).toEqual([['TestFrameWork.checkConditionError', 'toContainText', locator, { text: 'hello' }]])
+  expect(mockRpc.invocations).toEqual([['TestFrameWork.checkConditionError', 'toContainText', locator._parsed, { text: 'hello' }]])
 })
 
 test('toHaveJSProperty - element not found', async () => {
@@ -290,7 +290,7 @@ test('toHaveJSProperty - element not found', async () => {
     [
       'TestFrameWork.checkConditionError',
       'toHaveJSProperty',
-      locator,
+      locator._parsed,
       {
         key: 'disabled',
         value: 'true',
@@ -312,7 +312,7 @@ test('toHaveJSProperty - wrong value', async () => {
     [
       'TestFrameWork.checkConditionError',
       'toHaveJSProperty',
-      locator,
+      locator._parsed,
       {
         key: 'disabled',
         value: 'true',

--- a/packages/test-worker/test/Expect.test.ts
+++ b/packages/test-worker/test/Expect.test.ts
@@ -1,7 +1,10 @@
 import { expect, test } from '@jest/globals'
 import { RendererWorker } from '@lvce-editor/rpc-registry'
+import type { ILocator } from '../src/parts/ILocator/ILocator.ts'
+import { createLocator as createRealLocator } from '../src/parts/CreateLocator/CreateLocator.ts'
 import * as ExpectMod from '../src/parts/Expect/Expect.ts'
 import { parseCssSelector } from '../src/parts/ParseCssSelector/ParseCssSelector.ts'
+import * as WebViewState from '../src/parts/WebViewState/WebViewState.ts'
 
 const createLocator = (selector: string = 'button'): any => {
   return {
@@ -21,7 +24,39 @@ test('toHaveText: ok path', async () => {
   const expectLocator = ExpectMod.expect(locator)
   await expectLocator.toHaveText('Hello')
 
-  expect(mockRpc.invocations).toEqual([['TestFrameWork.checkSingleElementCondition', locator, 'toHaveText', { text: 'Hello' }]])
+  expect(mockRpc.invocations).toEqual([['TestFrameWork.checkSingleElementCondition', locator._parsed, 'toHaveText', { text: 'Hello' }]])
+})
+
+test('sends chained, has-text, and nth locator data without duplicate selector text', async () => {
+  using mockRpc = RendererWorker.registerMockRpc({
+    'TestFrameWork.checkSingleElementCondition'() {
+      return {}
+    },
+  })
+
+  const locator = createRealLocator('form', { hasText: 'Settings' }).locator('button').nth(2) as ILocator
+  const expectLocator = ExpectMod.expect(locator)
+  await expectLocator.toBeVisible()
+
+  expect(mockRpc.invocations).toEqual([['TestFrameWork.checkSingleElementCondition', locator._parsed, 'toBeVisible', {}]])
+})
+
+test('keeps legacy locator payload for webview conditions', async () => {
+  const invocations: any[] = []
+  WebViewState.set('webview-1', {
+    async invoke(...params: readonly any[]) {
+      invocations.push(params)
+      return {}
+    },
+  })
+  const locator = {
+    ...createLocator('button'),
+    webViewId: 'webview-1',
+  }
+
+  await ExpectMod.expect(locator).toBeVisible()
+
+  expect(invocations).toEqual([['TestFrameWork.checkSingleElementCondition', locator, 'toBeVisible', {}]])
 })
 
 test('toHaveText: error path builds ConditionErrors', async () => {
@@ -42,8 +77,8 @@ test('toHaveText: error path builds ConditionErrors', async () => {
 
   // Verify the RPC was called
   expect(mockRpc.invocations).toEqual([
-    ['TestFrameWork.checkSingleElementCondition', locator, 'toHaveText', { text: 'World' }],
-    ['TestFrameWork.checkConditionError', 'toHaveText', locator, { text: 'World' }],
+    ['TestFrameWork.checkSingleElementCondition', locator._parsed, 'toHaveText', { text: 'World' }],
+    ['TestFrameWork.checkConditionError', 'toHaveText', locator._parsed, { text: 'World' }],
   ])
 })
 
@@ -56,7 +91,7 @@ test('toHaveCount: validates number', async () => {
   const locator = createLocator('.item')
   const expectLocator = ExpectMod.expect(locator)
   await expectLocator.toHaveCount(2)
-  expect(mockRpc.invocations).toEqual([['TestFrameWork.checkMultiElementCondition', locator, 'toHaveCount', { count: 2 }]])
+  expect(mockRpc.invocations).toEqual([['TestFrameWork.checkMultiElementCondition', locator._parsed, 'toHaveCount', { count: 2 }]])
 })
 
 test('toBeVisible: negated throws guidance', async () => {
@@ -82,8 +117,8 @@ test('checkMultiElementCondition: error path builds ConditionErrors', async () =
   })
 
   expect(mockRpc.invocations).toEqual([
-    ['TestFrameWork.checkMultiElementCondition', locator, 'toHaveCount', { count: 2 }],
-    ['TestFrameWork.checkConditionError', 'toHaveCount', locator],
+    ['TestFrameWork.checkMultiElementCondition', locator._parsed, 'toHaveCount', { count: 2 }],
+    ['TestFrameWork.checkConditionError', 'toHaveCount', locator._parsed],
   ])
 })
 
@@ -98,7 +133,7 @@ test('toBeVisible: success path', async () => {
   const expectLocator = ExpectMod.expect(locator)
   await expectLocator.toBeVisible()
 
-  expect(mockRpc.invocations).toEqual([['TestFrameWork.checkSingleElementCondition', locator, 'toBeVisible', {}]])
+  expect(mockRpc.invocations).toEqual([['TestFrameWork.checkSingleElementCondition', locator._parsed, 'toBeVisible', {}]])
 })
 
 test('toContainText: success path', async () => {
@@ -112,7 +147,7 @@ test('toContainText: success path', async () => {
   const expectLocator = ExpectMod.expect(locator)
   await expectLocator.toContainText('Hello World')
 
-  expect(mockRpc.invocations).toEqual([['TestFrameWork.checkSingleElementCondition', locator, 'toContainText', { text: 'Hello World' }]])
+  expect(mockRpc.invocations).toEqual([['TestFrameWork.checkSingleElementCondition', locator._parsed, 'toContainText', { text: 'Hello World' }]])
 })
 
 test('toContainText: error path', async () => {
@@ -132,8 +167,8 @@ test('toContainText: error path', async () => {
   })
 
   expect(mockRpc.invocations).toEqual([
-    ['TestFrameWork.checkSingleElementCondition', locator, 'toContainText', { text: 'World' }],
-    ['TestFrameWork.checkConditionError', 'toContainText', locator, { text: 'World' }],
+    ['TestFrameWork.checkSingleElementCondition', locator._parsed, 'toContainText', { text: 'World' }],
+    ['TestFrameWork.checkConditionError', 'toContainText', locator._parsed, { text: 'World' }],
   ])
 })
 
@@ -148,7 +183,7 @@ test('toHaveValue: success path', async () => {
   const expectLocator = ExpectMod.expect(locator)
   await expectLocator.toHaveValue('test value')
 
-  expect(mockRpc.invocations).toEqual([['TestFrameWork.checkSingleElementCondition', locator, 'toHaveValue', { value: 'test value' }]])
+  expect(mockRpc.invocations).toEqual([['TestFrameWork.checkSingleElementCondition', locator._parsed, 'toHaveValue', { value: 'test value' }]])
 })
 
 test('toHaveValue: error path', async () => {
@@ -167,7 +202,7 @@ test('toHaveValue: error path', async () => {
     message: expect.stringContaining('expected selector input to have value expected value'),
   })
 
-  expect(mockRpc.invocations).toEqual([['TestFrameWork.checkSingleElementCondition', locator, 'toHaveValue', { value: 'expected value' }]])
+  expect(mockRpc.invocations).toEqual([['TestFrameWork.checkSingleElementCondition', locator._parsed, 'toHaveValue', { value: 'expected value' }]])
 })
 
 test('toBeFocused: success path', async () => {
@@ -181,7 +216,7 @@ test('toBeFocused: success path', async () => {
   const expectLocator = ExpectMod.expect(locator)
   await expectLocator.toBeFocused()
 
-  expect(mockRpc.invocations).toEqual([['TestFrameWork.checkSingleElementCondition', locator, 'toBeFocused', undefined]])
+  expect(mockRpc.invocations).toEqual([['TestFrameWork.checkSingleElementCondition', locator._parsed, 'toBeFocused', undefined]])
 })
 
 test('toBeFocused: error path', async () => {
@@ -201,8 +236,8 @@ test('toBeFocused: error path', async () => {
   })
 
   expect(mockRpc.invocations).toEqual([
-    ['TestFrameWork.checkSingleElementCondition', locator, 'toBeFocused', undefined],
-    ['TestFrameWork.checkConditionError', 'toBeFocused', locator, undefined],
+    ['TestFrameWork.checkSingleElementCondition', locator._parsed, 'toBeFocused', undefined],
+    ['TestFrameWork.checkConditionError', 'toBeFocused', locator._parsed, undefined],
   ])
 })
 
@@ -217,7 +252,7 @@ test('toHaveCSS: success path', async () => {
   const expectLocator = ExpectMod.expect(locator)
   await expectLocator.toHaveCSS('color', 'red')
 
-  expect(mockRpc.invocations).toEqual([['TestFrameWork.checkSingleElementCondition', locator, 'toHaveCss', { key: 'color', value: 'red' }]])
+  expect(mockRpc.invocations).toEqual([['TestFrameWork.checkSingleElementCondition', locator._parsed, 'toHaveCss', { key: 'color', value: 'red' }]])
 })
 
 test('toHaveCSS: error path', async () => {
@@ -237,8 +272,8 @@ test('toHaveCSS: error path', async () => {
   })
 
   expect(mockRpc.invocations).toEqual([
-    ['TestFrameWork.checkSingleElementCondition', locator, 'toHaveCss', { key: 'color', value: 'red' }],
-    ['TestFrameWork.checkConditionError', 'toHaveCss', locator, { key: 'color', value: 'red' }],
+    ['TestFrameWork.checkSingleElementCondition', locator._parsed, 'toHaveCss', { key: 'color', value: 'red' }],
+    ['TestFrameWork.checkConditionError', 'toHaveCss', locator._parsed, { key: 'color', value: 'red' }],
   ])
 })
 
@@ -253,7 +288,9 @@ test('toHaveAttribute: success path', async () => {
   const expectLocator = ExpectMod.expect(locator)
   await expectLocator.toHaveAttribute('type', 'text')
 
-  expect(mockRpc.invocations).toEqual([['TestFrameWork.checkSingleElementCondition', locator, 'toHaveAttribute', { key: 'type', value: 'text' }]])
+  expect(mockRpc.invocations).toEqual([
+    ['TestFrameWork.checkSingleElementCondition', locator._parsed, 'toHaveAttribute', { key: 'type', value: 'text' }],
+  ])
 })
 
 test('toHaveAttribute: error path', async () => {
@@ -273,8 +310,8 @@ test('toHaveAttribute: error path', async () => {
   })
 
   expect(mockRpc.invocations).toEqual([
-    ['TestFrameWork.checkSingleElementCondition', locator, 'toHaveAttribute', { key: 'type', value: 'text' }],
-    ['TestFrameWork.checkConditionError', 'toHaveAttribute', locator, { key: 'type', value: 'text' }],
+    ['TestFrameWork.checkSingleElementCondition', locator._parsed, 'toHaveAttribute', { key: 'type', value: 'text' }],
+    ['TestFrameWork.checkConditionError', 'toHaveAttribute', locator._parsed, { key: 'type', value: 'text' }],
   ])
 })
 
@@ -290,7 +327,7 @@ test('toHaveJSProperty: success path', async () => {
   await expectLocator.toHaveJSProperty('innerHTML', '<span>test</span>')
 
   expect(mockRpc.invocations).toEqual([
-    ['TestFrameWork.checkSingleElementCondition', locator, 'toHaveJSProperty', { key: 'innerHTML', value: '<span>test</span>' }],
+    ['TestFrameWork.checkSingleElementCondition', locator._parsed, 'toHaveJSProperty', { key: 'innerHTML', value: '<span>test</span>' }],
   ])
 })
 
@@ -311,8 +348,8 @@ test('toHaveJSProperty: error path', async () => {
   })
 
   expect(mockRpc.invocations).toEqual([
-    ['TestFrameWork.checkSingleElementCondition', locator, 'toHaveJSProperty', { key: 'innerHTML', value: '<span>test</span>' }],
-    ['TestFrameWork.checkConditionError', 'toHaveJSProperty', locator, { key: 'innerHTML', value: '<span>test</span>' }],
+    ['TestFrameWork.checkSingleElementCondition', locator._parsed, 'toHaveJSProperty', { key: 'innerHTML', value: '<span>test</span>' }],
+    ['TestFrameWork.checkConditionError', 'toHaveJSProperty', locator._parsed, { key: 'innerHTML', value: '<span>test</span>' }],
   ])
 })
 
@@ -327,7 +364,7 @@ test('toHaveClass: success path', async () => {
   const expectLocator = ExpectMod.expect(locator)
   await expectLocator.toHaveClass('active')
 
-  expect(mockRpc.invocations).toEqual([['TestFrameWork.checkSingleElementCondition', locator, 'toHaveClass', { className: 'active' }]])
+  expect(mockRpc.invocations).toEqual([['TestFrameWork.checkSingleElementCondition', locator._parsed, 'toHaveClass', { className: 'active' }]])
 })
 
 test('toHaveClass: error path', async () => {
@@ -347,8 +384,8 @@ test('toHaveClass: error path', async () => {
   })
 
   expect(mockRpc.invocations).toEqual([
-    ['TestFrameWork.checkSingleElementCondition', locator, 'toHaveClass', { className: 'active' }],
-    ['TestFrameWork.checkConditionError', 'toHaveClass', locator, { className: 'active' }],
+    ['TestFrameWork.checkSingleElementCondition', locator._parsed, 'toHaveClass', { className: 'active' }],
+    ['TestFrameWork.checkConditionError', 'toHaveClass', locator._parsed, { className: 'active' }],
   ])
 })
 
@@ -363,7 +400,7 @@ test('toHaveId: success path', async () => {
   const expectLocator = ExpectMod.expect(locator)
   await expectLocator.toHaveId('my-element')
 
-  expect(mockRpc.invocations).toEqual([['TestFrameWork.checkSingleElementCondition', locator, 'toHaveId', { id: 'my-element' }]])
+  expect(mockRpc.invocations).toEqual([['TestFrameWork.checkSingleElementCondition', locator._parsed, 'toHaveId', { id: 'my-element' }]])
 })
 
 test('toHaveId: error path', async () => {
@@ -383,8 +420,8 @@ test('toHaveId: error path', async () => {
   })
 
   expect(mockRpc.invocations).toEqual([
-    ['TestFrameWork.checkSingleElementCondition', locator, 'toHaveId', { id: 'my-element' }],
-    ['TestFrameWork.checkConditionError', 'toHaveId', locator, { id: 'my-element' }],
+    ['TestFrameWork.checkSingleElementCondition', locator._parsed, 'toHaveId', { id: 'my-element' }],
+    ['TestFrameWork.checkConditionError', 'toHaveId', locator._parsed, { id: 'my-element' }],
   ])
 })
 
@@ -399,7 +436,7 @@ test('toBeHidden: success path', async () => {
   const expectLocator = ExpectMod.expect(locator)
   await expectLocator.toBeHidden()
 
-  expect(mockRpc.invocations).toEqual([['TestFrameWork.checkMultiElementCondition', locator, 'toBeHidden', {}]])
+  expect(mockRpc.invocations).toEqual([['TestFrameWork.checkMultiElementCondition', locator._parsed, 'toBeHidden', {}]])
 })
 
 test('toBeHidden: error path', async () => {
@@ -418,5 +455,5 @@ test('toBeHidden: error path', async () => {
     message: expect.stringContaining('expected div to be hidden'),
   })
 
-  expect(mockRpc.invocations).toEqual([['TestFrameWork.checkMultiElementCondition', locator, 'toBeHidden', {}]])
+  expect(mockRpc.invocations).toEqual([['TestFrameWork.checkMultiElementCondition', locator._parsed, 'toBeHidden', {}]])
 })

--- a/packages/test-worker/test/GetConditionLocator.test.ts
+++ b/packages/test-worker/test/GetConditionLocator.test.ts
@@ -1,0 +1,15 @@
+import { expect, test } from '@jest/globals'
+import type { ILocator } from '../src/parts/ILocator/ILocator.ts'
+import { createLocator } from '../src/parts/CreateLocator/CreateLocator.ts'
+import * as GetConditionLocator from '../src/parts/GetConditionLocator/GetConditionLocator.ts'
+
+test('returns parsed locator for renderer conditions', () => {
+  const locator = createLocator('form').locator('button').nth(2) as ILocator
+  expect(GetConditionLocator.getConditionLocator(locator)).toBe(locator._parsed)
+})
+
+test('returns full locator for webview conditions', () => {
+  const locator = createLocator('button') as any
+  locator.webViewId = 'webview-1'
+  expect(GetConditionLocator.getConditionLocator(locator)).toBe(locator)
+})

--- a/packages/test-worker/test/TestFrameWorkComponentDiffView.test.ts
+++ b/packages/test-worker/test/TestFrameWorkComponentDiffView.test.ts
@@ -25,7 +25,7 @@ test('shouldHaveContentLeft', async () => {
   await DiffView.shouldHaveContentLeft('left content')
 
   expect(mockRpc.invocations).toEqual([
-    ['TestFrameWork.checkSingleElementCondition', createLocator('.DiffEditorContentLeft'), 'toHaveText', { text: 'left content' }],
+    ['TestFrameWork.checkSingleElementCondition', createLocator('.DiffEditorContentLeft')._parsed, 'toHaveText', { text: 'left content' }],
   ])
 })
 
@@ -39,7 +39,7 @@ test('shouldHaveContentRight', async () => {
   await DiffView.shouldHaveContentRight('right content')
 
   expect(mockRpc.invocations).toEqual([
-    ['TestFrameWork.checkSingleElementCondition', createLocator('.DiffEditorContentRight'), 'toHaveText', { text: 'right content' }],
+    ['TestFrameWork.checkSingleElementCondition', createLocator('.DiffEditorContentRight')._parsed, 'toHaveText', { text: 'right content' }],
   ])
 })
 

--- a/packages/test-worker/test/TestFrameWorkComponentProcessExplorer.test.ts
+++ b/packages/test-worker/test/TestFrameWorkComponentProcessExplorer.test.ts
@@ -3,6 +3,12 @@ import { RendererWorker } from '@lvce-editor/rpc-registry'
 import * as ProcessExplorer from '../src/parts/TestFrameWorkComponentProcessExplorer/TestFrameWorkComponentProcessExplorer.ts'
 
 const getSelector = (locator: any): string => {
+  if (Array.isArray(locator)) {
+    return locator
+      .filter((part) => part.type === 'css')
+      .map((part) => part.selector)
+      .join(' ')
+  }
   return locator._selector
 }
 


### PR DESCRIPTION
## Summary
- send parsed locator arrays for renderer condition checks and error details
- retain full locators locally for readable assertion errors
- preserve the legacy locator payload for WebView conditions

## Tests
- npm run type-check
- npm run lint
- npm test
- npm run build