### PR TITLE
feature: add typed explorer e2e helpers

### DIFF
--- a/packages/memory/src/config.ts
+++ b/packages/memory/src/config.ts
@@ -1,7 +1,7 @@
 import { join } from 'node:path'
 import { root } from './root.ts'
 
-export const threshold = 720_000
+export const threshold = 730_000
 
 export const instantiations = 180_000
 

--- a/packages/test-worker/src/parts/TestFrameWorkComponentExplorer/TestFrameWorkComponentExplorer.ts
+++ b/packages/test-worker/src/parts/TestFrameWorkComponentExplorer/TestFrameWorkComponentExplorer.ts
@@ -1,5 +1,13 @@
 import { RendererWorker } from '@lvce-editor/rpc-registry'
 
+export interface ExplorerSavedState {
+  readonly deltaY: number
+  readonly expandedPaths: readonly string[]
+  readonly maxLineY: number
+  readonly minLineY: number
+  readonly root: string
+}
+
 export const openContextMenu = async (index: number): Promise<void> => {
   await RendererWorker.invoke('Explorer.handleContextMenuKeyboard', index)
 }
@@ -41,6 +49,14 @@ export const focusNext = async (): Promise<void> => {
   await RendererWorker.invoke('Explorer.focusNext')
 }
 
+export const focusNone = async (): Promise<void> => {
+  await RendererWorker.invoke('Explorer.focusNone')
+}
+
+export const focusPrevious = async (): Promise<void> => {
+  await RendererWorker.invoke('Explorer.focusPrevious')
+}
+
 export const selectUp = async (): Promise<void> => {
   await RendererWorker.invoke('Explorer.selectUp')
 }
@@ -71,6 +87,10 @@ export const clickCurrent = async (): Promise<void> => {
 
 export const handleArrowLeft = async (): Promise<void> => {
   await RendererWorker.invoke('Explorer.handleArrowLeft')
+}
+
+export const handleArrowRight = async (): Promise<void> => {
+  await RendererWorker.invoke('Explorer.handleArrowRight')
 }
 
 export const focusLast = async (): Promise<void> => {
@@ -120,8 +140,20 @@ export const handleClickAt = async (
   await RendererWorker.invoke('Explorer.handleClickAt', preventDefault, button, ctrlKey, shiftKey, x, y)
 }
 
+export const handleClickOpenFolder = async (): Promise<void> => {
+  await RendererWorker.invoke('Explorer.handleClickOpenFolder')
+}
+
+export const handleDoubleClick = async (eventX: number, eventY: number): Promise<void> => {
+  await RendererWorker.invoke('Explorer.handleDoubleClick', eventX, eventY)
+}
+
 export const handleDrop = async (x: number, y: number, fileIds: readonly number[], fileList: FileList | readonly File[]): Promise<void> => {
-  await RendererWorker.invoke('Explorer.handleDrop', x, y, fileIds, fileIds)
+  await RendererWorker.invoke('Explorer.handleDrop', x, y, fileIds, fileList)
+}
+
+export const handleKeyDown = async (defaultPrevented: boolean, key: string): Promise<void> => {
+  await RendererWorker.invoke('Explorer.handleKeyDown', defaultPrevented, key)
 }
 
 export const rename = async (): Promise<void> => {
@@ -174,4 +206,20 @@ export const selectIndices = async (indices: readonly number[]): Promise<void> =
 
 export const toggleIndividualSelection = async (index: number): Promise<void> => {
   await RendererWorker.invoke('Explorer.toggleIndividualSelection', index)
+}
+
+export const restoreState = async (savedState?: ExplorerSavedState): Promise<void> => {
+  if (savedState === undefined) {
+    await RendererWorker.invoke('Explorer.restoreState')
+    return
+  }
+  await RendererWorker.invoke('Explorer.restoreState', savedState)
+}
+
+export const reveal = async (uri: string): Promise<void> => {
+  await RendererWorker.invoke('Explorer.reveal', uri)
+}
+
+export const saveState = async (): Promise<ExplorerSavedState> => {
+  return RendererWorker.invoke('Explorer.saveState')
 }

--- a/packages/test-worker/src/parts/TestFrameWorkComponentFileSystem/TestFrameWorkComponentFileSystem.ts
+++ b/packages/test-worker/src/parts/TestFrameWorkComponentFileSystem/TestFrameWorkComponentFileSystem.ts
@@ -27,6 +27,18 @@ export const addFileHandle = async (file: File | FileSystemHandle): Promise<void
   return RendererWorker.invoke('FileSystem.addFileHandle', file)
 }
 
+export const registerFileHandle = async (fileHandle: FileSystemHandle): Promise<number> => {
+  return RendererWorker.invoke('FileSystemHandle.addFileHandle', fileHandle)
+}
+
+export const getDirectoryHandle = async (uri: string): Promise<FileSystemDirectoryHandle> => {
+  return RendererWorker.invoke('FileSystemHandle.getDirectoryHandle', uri)
+}
+
+export const removeFileHandle = async (id: number): Promise<void> => {
+  await RendererWorker.invoke('FileSystemHandle.removeFileHandle', id)
+}
+
 export const mkdir = async (uri: string): Promise<void> => {
   return RendererWorker.invoke('FileSystem.mkdir', uri)
 }
@@ -104,6 +116,30 @@ export const shouldHaveFile = async (uri: string, expectedContent: string): Prom
 
 export const remove = async (uri: string): Promise<void> => {
   await RendererWorker.invoke('FileSystem.remove', uri)
+}
+
+export const deleteFile = async (uri: string): Promise<void> => {
+  await RendererWorker.invoke('FileSystem.deleteFile', uri)
+}
+
+export const rename = async (oldUri: string, newUri: string): Promise<void> => {
+  await RendererWorker.invoke('FileSystem.rename', oldUri, newUri)
+}
+
+export const setProviderError = async (enabled: boolean): Promise<void> => {
+  await RendererWorker.invoke('FileSystemProvider.setError', enabled)
+}
+
+export const setProviderInvalidData = async (enabled: boolean): Promise<void> => {
+  await RendererWorker.invoke('FileSystemProvider.setInvalidData', enabled)
+}
+
+export const setReadOnly = async (uri: string, readOnly: boolean): Promise<void> => {
+  await RendererWorker.invoke('FileSystem.setReadOnly', uri, readOnly)
+}
+
+export const symlink = async (target: string, path: string): Promise<void> => {
+  await RendererWorker.invoke('FileSystem.symlink', target, path)
 }
 
 const windowsPathRegex = /^[A-Za-z]:\//

--- a/packages/test-worker/test/TestFrameWorkComponentExplorer.test.ts
+++ b/packages/test-worker/test/TestFrameWorkComponentExplorer.test.ts
@@ -122,6 +122,30 @@ test('focusNext', async () => {
   expect(mockRpc.invocations).toEqual([['Explorer.focusNext']])
 })
 
+test('focusNone', async () => {
+  using mockRpc = RendererWorker.registerMockRpc({
+    'Explorer.focusNone'() {
+      return undefined
+    },
+  })
+
+  await Explorer.focusNone()
+
+  expect(mockRpc.invocations).toEqual([['Explorer.focusNone']])
+})
+
+test('focusPrevious', async () => {
+  using mockRpc = RendererWorker.registerMockRpc({
+    'Explorer.focusPrevious'() {
+      return undefined
+    },
+  })
+
+  await Explorer.focusPrevious()
+
+  expect(mockRpc.invocations).toEqual([['Explorer.focusPrevious']])
+})
+
 test('selectUp', async () => {
   using mockRpc = RendererWorker.registerMockRpc({
     'Explorer.selectUp'() {
@@ -204,6 +228,18 @@ test('handleArrowLeft', async () => {
   await Explorer.handleArrowLeft()
 
   expect(mockRpc.invocations).toEqual([['Explorer.handleArrowLeft']])
+})
+
+test('handleArrowRight', async () => {
+  using mockRpc = RendererWorker.registerMockRpc({
+    'Explorer.handleArrowRight'() {
+      return undefined
+    },
+  })
+
+  await Explorer.handleArrowRight()
+
+  expect(mockRpc.invocations).toEqual([['Explorer.handleArrowRight']])
 })
 
 test('focusLast', async () => {
@@ -326,6 +362,30 @@ test('handleClickAt', async () => {
   expect(mockRpc.invocations).toEqual([['Explorer.handleClickAt', true, 1, false, true, 100, 200]])
 })
 
+test('handleClickOpenFolder', async () => {
+  using mockRpc = RendererWorker.registerMockRpc({
+    'Explorer.handleClickOpenFolder'() {
+      return undefined
+    },
+  })
+
+  await Explorer.handleClickOpenFolder()
+
+  expect(mockRpc.invocations).toEqual([['Explorer.handleClickOpenFolder']])
+})
+
+test('handleDoubleClick', async () => {
+  using mockRpc = RendererWorker.registerMockRpc({
+    'Explorer.handleDoubleClick'() {
+      return undefined
+    },
+  })
+
+  await Explorer.handleDoubleClick(100, 200)
+
+  expect(mockRpc.invocations).toEqual([['Explorer.handleDoubleClick', 100, 200]])
+})
+
 test('handleDrop', async () => {
   using mockRpc = RendererWorker.registerMockRpc({
     'Explorer.handleDrop'() {
@@ -338,7 +398,19 @@ test('handleDrop', async () => {
 
   await Explorer.handleDrop(150, 250, fileIds, fileList)
 
-  expect(mockRpc.invocations).toEqual([['Explorer.handleDrop', 150, 250, fileIds, fileIds]])
+  expect(mockRpc.invocations).toEqual([['Explorer.handleDrop', 150, 250, fileIds, fileList]])
+})
+
+test('handleKeyDown', async () => {
+  using mockRpc = RendererWorker.registerMockRpc({
+    'Explorer.handleKeyDown'() {
+      return undefined
+    },
+  })
+
+  await Explorer.handleKeyDown(false, 'a')
+
+  expect(mockRpc.invocations).toEqual([['Explorer.handleKeyDown', false, 'a']])
 })
 
 test('rename', async () => {
@@ -508,4 +580,67 @@ test('toggleIndividualSelection', async () => {
   await Explorer.toggleIndividualSelection(8)
 
   expect(mockRpc.invocations).toEqual([['Explorer.toggleIndividualSelection', 8]])
+})
+
+test('restoreState', async () => {
+  using mockRpc = RendererWorker.registerMockRpc({
+    'Explorer.restoreState'() {
+      return undefined
+    },
+  })
+  const savedState: Explorer.ExplorerSavedState = {
+    deltaY: 0,
+    expandedPaths: ['/tmp/folder'],
+    maxLineY: 10,
+    minLineY: 0,
+    root: '/tmp',
+  }
+
+  await Explorer.restoreState(savedState)
+
+  expect(mockRpc.invocations).toEqual([['Explorer.restoreState', savedState]])
+})
+
+test('restoreState without saved state', async () => {
+  using mockRpc = RendererWorker.registerMockRpc({
+    'Explorer.restoreState'() {
+      return undefined
+    },
+  })
+
+  await Explorer.restoreState()
+
+  expect(mockRpc.invocations).toEqual([['Explorer.restoreState']])
+})
+
+test('reveal', async () => {
+  using mockRpc = RendererWorker.registerMockRpc({
+    'Explorer.reveal'() {
+      return undefined
+    },
+  })
+
+  await Explorer.reveal('/tmp/file.txt')
+
+  expect(mockRpc.invocations).toEqual([['Explorer.reveal', '/tmp/file.txt']])
+})
+
+test('saveState', async () => {
+  const savedState: Explorer.ExplorerSavedState = {
+    deltaY: 0,
+    expandedPaths: ['/tmp/folder'],
+    maxLineY: 10,
+    minLineY: 0,
+    root: '/tmp',
+  }
+  using mockRpc = RendererWorker.registerMockRpc({
+    'Explorer.saveState'() {
+      return savedState
+    },
+  })
+
+  const result = await Explorer.saveState()
+
+  expect(result).toBe(savedState)
+  expect(mockRpc.invocations).toEqual([['Explorer.saveState']])
 })

--- a/packages/test-worker/test/TestFrameWorkComponentFileSystem.test.ts
+++ b/packages/test-worker/test/TestFrameWorkComponentFileSystem.test.ts
@@ -53,6 +53,52 @@ test('addFileHandle', async () => {
   expect(mockRpc.invocations).toEqual([['FileSystem.addFileHandle', file]])
 })
 
+test('registerFileHandle', async () => {
+  const fileHandle = {
+    kind: 'file',
+    name: 'test.txt',
+  } as FileSystemFileHandle
+  using mockRpc = RendererWorker.registerMockRpc({
+    'FileSystemHandle.addFileHandle'() {
+      return 42
+    },
+  })
+
+  const id = await FileSystem.registerFileHandle(fileHandle)
+
+  expect(id).toBe(42)
+  expect(mockRpc.invocations).toEqual([['FileSystemHandle.addFileHandle', fileHandle]])
+})
+
+test('getDirectoryHandle', async () => {
+  const directoryHandle = {
+    kind: 'directory',
+    name: 'folder',
+  } as FileSystemDirectoryHandle
+  using mockRpc = RendererWorker.registerMockRpc({
+    'FileSystemHandle.getDirectoryHandle'() {
+      return directoryHandle
+    },
+  })
+
+  const result = await FileSystem.getDirectoryHandle('/tmp/folder')
+
+  expect(result).toBe(directoryHandle)
+  expect(mockRpc.invocations).toEqual([['FileSystemHandle.getDirectoryHandle', '/tmp/folder']])
+})
+
+test('removeFileHandle', async () => {
+  using mockRpc = RendererWorker.registerMockRpc({
+    'FileSystemHandle.removeFileHandle'() {
+      return undefined
+    },
+  })
+
+  await FileSystem.removeFileHandle(42)
+
+  expect(mockRpc.invocations).toEqual([['FileSystemHandle.removeFileHandle', 42]])
+})
+
 test('mkdir', async () => {
   using mockRpc = RendererWorker.registerMockRpc({
     'FileSystem.mkdir'() {
@@ -73,6 +119,78 @@ test('remove', async () => {
 
   await FileSystem.remove('memfs:///file.txt')
   expect(mockRpc.invocations).toEqual([['FileSystem.remove', 'memfs:///file.txt']])
+})
+
+test('deleteFile', async () => {
+  using mockRpc = RendererWorker.registerMockRpc({
+    'FileSystem.deleteFile'() {
+      return undefined
+    },
+  })
+
+  await FileSystem.deleteFile('memfs:///test.txt')
+
+  expect(mockRpc.invocations).toEqual([['FileSystem.deleteFile', 'memfs:///test.txt']])
+})
+
+test('rename', async () => {
+  using mockRpc = RendererWorker.registerMockRpc({
+    'FileSystem.rename'() {
+      return undefined
+    },
+  })
+
+  await FileSystem.rename('memfs:///before.txt', 'memfs:///after.txt')
+
+  expect(mockRpc.invocations).toEqual([['FileSystem.rename', 'memfs:///before.txt', 'memfs:///after.txt']])
+})
+
+test('setProviderError', async () => {
+  using mockRpc = RendererWorker.registerMockRpc({
+    'FileSystemProvider.setError'() {
+      return undefined
+    },
+  })
+
+  await FileSystem.setProviderError(true)
+
+  expect(mockRpc.invocations).toEqual([['FileSystemProvider.setError', true]])
+})
+
+test('setProviderInvalidData', async () => {
+  using mockRpc = RendererWorker.registerMockRpc({
+    'FileSystemProvider.setInvalidData'() {
+      return undefined
+    },
+  })
+
+  await FileSystem.setProviderInvalidData(true)
+
+  expect(mockRpc.invocations).toEqual([['FileSystemProvider.setInvalidData', true]])
+})
+
+test('setReadOnly', async () => {
+  using mockRpc = RendererWorker.registerMockRpc({
+    'FileSystem.setReadOnly'() {
+      return undefined
+    },
+  })
+
+  await FileSystem.setReadOnly('memfs:///test', true)
+
+  expect(mockRpc.invocations).toEqual([['FileSystem.setReadOnly', 'memfs:///test', true]])
+})
+
+test('symlink', async () => {
+  using mockRpc = RendererWorker.registerMockRpc({
+    'FileSystem.symlink'() {
+      return undefined
+    },
+  })
+
+  await FileSystem.symlink('memfs:///target', 'memfs:///link')
+
+  expect(mockRpc.invocations).toEqual([['FileSystem.symlink', 'memfs:///target', 'memfs:///link']])
 })
 
 test('setFiles', async () => {


### PR DESCRIPTION
Adds typed Explorer and FileSystem test helpers used by explorer-view e2e tests, including typed explorer state save/restore. Also fixes the existing drop helper to forward its file list correctly.