### PR TITLE
feature: add typed extension detail test apis

### DIFF
--- a/packages/test-worker/src/parts/Api/Api.ts
+++ b/packages/test-worker/src/parts/Api/Api.ts
@@ -7,6 +7,7 @@ import type * as Audio from '../TestFrameWorkComponentAudio/TestFrameWorkCompone
 import type * as Chat from '../TestFrameWorkComponentChat/TestFrameWorkComponentChat.ts'
 import type * as ChatDebug from '../TestFrameWorkComponentChatDebug/TestFrameWorkComponentChatDebug.ts'
 import type * as ClipBoard from '../TestFrameWorkComponentClipBoard/TestFrameworkComponentClipBoard.ts'
+import type * as ColorTheme from '../TestFrameWorkComponentColorTheme/TestFrameWorkComponentColorTheme.ts'
 import type * as Command from '../TestFrameWorkComponentCommand/TestFrameWorkComponentCommand.ts'
 import type * as ContextMenu from '../TestFrameWorkComponentContextMenu/TestFrameWorkComponentContextMenu.ts'
 import type * as Developer from '../TestFrameWorkComponentDeveloper/TestFrameWorkComponentDeveloper.ts'
@@ -69,6 +70,7 @@ export interface Api {
   ChatDebug: typeof ChatDebug
   ClipBoard: typeof ClipBoard
   ColorPicker: typeof ColorPicker
+  ColorTheme: typeof ColorTheme
   Command: typeof Command
   ContextMenu: typeof ContextMenu
   Developer: typeof Developer

--- a/packages/test-worker/src/parts/CreateApi/CreateApi.ts
+++ b/packages/test-worker/src/parts/CreateApi/CreateApi.ts
@@ -7,6 +7,7 @@ import * as Audio from '../TestFrameWorkComponentAudio/TestFrameWorkComponentAud
 import * as Chat from '../TestFrameWorkComponentChat/TestFrameWorkComponentChat.ts'
 import * as ChatDebug from '../TestFrameWorkComponentChatDebug/TestFrameWorkComponentChatDebug.ts'
 import * as ClipBoard from '../TestFrameWorkComponentClipBoard/TestFrameworkComponentClipBoard.ts'
+import * as ColorTheme from '../TestFrameWorkComponentColorTheme/TestFrameWorkComponentColorTheme.ts'
 import * as Command from '../TestFrameWorkComponentCommand/TestFrameWorkComponentCommand.ts'
 import * as ContextMenu from '../TestFrameWorkComponentContextMenu/TestFrameWorkComponentContextMenu.ts'
 import * as Developer from '../TestFrameWorkComponentDeveloper/TestFrameWorkComponentDeveloper.ts'
@@ -66,6 +67,7 @@ export const createApi = (platform: number, assetDir: string): Api => {
     ChatDebug,
     ClipBoard,
     ColorPicker,
+    ColorTheme,
     Command,
     ContextMenu,
     Developer,

--- a/packages/test-worker/src/parts/TestFrameWorkComponent/TestFrameWorkComponent.ts
+++ b/packages/test-worker/src/parts/TestFrameWorkComponent/TestFrameWorkComponent.ts
@@ -5,6 +5,7 @@ export * as Chat from '../TestFrameWorkComponentChat/TestFrameWorkComponentChat.
 export * as ChatDebug from '../TestFrameWorkComponentChatDebug/TestFrameWorkComponentChatDebug.ts'
 export * as ClipBoard from '../TestFrameWorkComponentClipBoard/TestFrameworkComponentClipBoard.ts'
 export * as ColorPicker from '../TestFrameWorkComponentColorPicker/TestFrameWorkComponentColorPicker.ts'
+export * as ColorTheme from '../TestFrameWorkComponentColorTheme/TestFrameWorkComponentColorTheme.ts'
 export * as Command from '../TestFrameWorkComponentCommand/TestFrameWorkComponentCommand.ts'
 export * as ContextMenu from '../TestFrameWorkComponentContextMenu/TestFrameWorkComponentContextMenu.ts'
 export * as Developer from '../TestFrameWorkComponentDeveloper/TestFrameWorkComponentDeveloper.ts'

--- a/packages/test-worker/src/parts/TestFrameWorkComponentColorTheme/TestFrameWorkComponentColorTheme.ts
+++ b/packages/test-worker/src/parts/TestFrameWorkComponentColorTheme/TestFrameWorkComponentColorTheme.ts
@@ -1,0 +1,5 @@
+import { RendererWorker } from '@lvce-editor/rpc-registry'
+
+export const setColorTheme = async (id: string): Promise<void> => {
+  await RendererWorker.invoke('ColorTheme.setColorTheme', id)
+}

--- a/packages/test-worker/src/parts/TestFrameWorkComponentExtension/TestFrameWorkComponentExtension.ts
+++ b/packages/test-worker/src/parts/TestFrameWorkComponentExtension/TestFrameWorkComponentExtension.ts
@@ -59,3 +59,7 @@ export const addNodeExtension = async (relativePath: string): Promise<void> => {
   const absolutePath = relativePath
   await RendererWorker.invoke('ExtensionMeta.addNodeExtension', absolutePath)
 }
+
+export const activateByEvent = async (event: string, assetDir: string, platform: number): Promise<void> => {
+  await RendererWorker.invoke('ExtensionHostManagement.activateByEvent', event, assetDir, platform)
+}

--- a/packages/test-worker/src/parts/TestFrameWorkComponentExtensionDetail/TestFrameWorkComponentExtensionDetail.ts
+++ b/packages/test-worker/src/parts/TestFrameWorkComponentExtensionDetail/TestFrameWorkComponentExtensionDetail.ts
@@ -1,5 +1,15 @@
 import { RendererWorker } from '@lvce-editor/rpc-registry'
 
+export interface GithubApiMock {
+  readonly body?: unknown
+  readonly headers?: Readonly<Record<string, string>>
+  readonly message?: string
+  readonly releaseCount?: number
+  readonly status?: number
+  readonly statusText?: string
+  readonly type: 'generated' | 'invalid-json' | 'network-error' | 'response' | 'success'
+}
+
 export const handleClickCategory = async (categoryId: string): Promise<void> => {
   await RendererWorker.invoke('ExtensionDetail.handleClickCategory', categoryId)
 }
@@ -103,4 +113,12 @@ export const hideSizeLink = async (): Promise<void> => {
 
 export const handleTabFocus = async (tabName: string): Promise<void> => {
   return RendererWorker.invoke('ExtensionDetail.handleTabFocus', tabName)
+}
+
+export const handleClickSettings = async (x: number, y: number): Promise<void> => {
+  await RendererWorker.invoke('ExtensionDetail.handleClickSettings', x, y)
+}
+
+export const mockGithubApi = async (options: GithubApiMock): Promise<void> => {
+  await RendererWorker.invoke('ExtensionDetail.mockGithubApi', options)
 }

--- a/packages/test-worker/test/TestFrameWorkComponentColorTheme.test.ts
+++ b/packages/test-worker/test/TestFrameWorkComponentColorTheme.test.ts
@@ -1,0 +1,15 @@
+import { expect, test } from '@jest/globals'
+import { RendererWorker } from '@lvce-editor/rpc-registry'
+import * as ColorTheme from '../src/parts/TestFrameWorkComponentColorTheme/TestFrameWorkComponentColorTheme.ts'
+
+test('setColorTheme', async () => {
+  using mockRpc = RendererWorker.registerMockRpc({
+    'ColorTheme.setColorTheme'() {
+      return undefined
+    },
+  })
+
+  await ColorTheme.setColorTheme('slime-theme')
+
+  expect(mockRpc.invocations).toEqual([['ColorTheme.setColorTheme', 'slime-theme']])
+})

--- a/packages/test-worker/test/TestFrameWorkComponentExtension.test.ts
+++ b/packages/test-worker/test/TestFrameWorkComponentExtension.test.ts
@@ -91,3 +91,15 @@ test('disableWorkspace', async () => {
 
   expect(mockExtensionManagementRpc.invocations).toEqual([['Extensions.disableWorkspace', 'test.extension']])
 })
+
+test('activateByEvent', async () => {
+  using mockRpc = RendererWorker.registerMockRpc({
+    'ExtensionHostManagement.activateByEvent'() {
+      return undefined
+    },
+  })
+
+  await Extension.activateByEvent('onCommand:test.run', '/asset', 2)
+
+  expect(mockRpc.invocations).toEqual([['ExtensionHostManagement.activateByEvent', 'onCommand:test.run', '/asset', 2]])
+})

--- a/packages/test-worker/test/TestFrameWorkComponentExtensionDetail.test.ts
+++ b/packages/test-worker/test/TestFrameWorkComponentExtensionDetail.test.ts
@@ -184,3 +184,27 @@ test('handleTabFocus', async () => {
   await ExtensionDetail.handleTabFocus('Details')
   expect(mockRpc.invocations).toEqual([['ExtensionDetail.handleTabFocus', 'Details']])
 })
+
+test('handleClickSettings', async () => {
+  using mockRpc = RendererWorker.registerMockRpc({
+    'ExtensionDetail.handleClickSettings'() {
+      return undefined
+    },
+  })
+  await ExtensionDetail.handleClickSettings(100, 200)
+  expect(mockRpc.invocations).toEqual([['ExtensionDetail.handleClickSettings', 100, 200]])
+})
+
+test('mockGithubApi', async () => {
+  using mockRpc = RendererWorker.registerMockRpc({
+    'ExtensionDetail.mockGithubApi'() {
+      return undefined
+    },
+  })
+  const options = {
+    body: [{ name: 'Version 1.0.0' }],
+    type: 'success',
+  } as const
+  await ExtensionDetail.mockGithubApi(options)
+  expect(mockRpc.invocations).toEqual([['ExtensionDetail.mockGithubApi', options]])
+})


### PR DESCRIPTION
Add typed test-worker page-object APIs for color themes, extension activation, extension detail settings, and GitHub API mocking.