### PR TITLE
fix: preserve image context menu coordinates

### DIFF
--- a/packages/test-worker/src/parts/TestFrameWorkComponentExtensionDetail/TestFrameWorkComponentExtensionDetail.ts
+++ b/packages/test-worker/src/parts/TestFrameWorkComponentExtensionDetail/TestFrameWorkComponentExtensionDetail.ts
@@ -71,8 +71,8 @@ export const handleClickUninstall = (): Promise<void> => {
   return RendererWorker.invoke('ExtensionDetail.handleClickUninstall')
 }
 
-export const handleImageContextMenu = (): Promise<void> => {
-  return RendererWorker.invoke('ExtensionDetail.handleImageContextMenu')
+export const handleImageContextMenu = (x: number, y: number): Promise<void> => {
+  return RendererWorker.invoke('ExtensionDetail.handleImageContextMenu', x, y)
 }
 
 export const openFeature = (featureName: string): Promise<void> => {

--- a/packages/test-worker/test/TestFrameWorkComponentExtensionDetail.test.ts
+++ b/packages/test-worker/test/TestFrameWorkComponentExtensionDetail.test.ts
@@ -161,8 +161,8 @@ test('handleImageContextMenu', async () => {
       return undefined
     },
   })
-  await ExtensionDetail.handleImageContextMenu()
-  expect(mockRpc.invocations).toEqual([['ExtensionDetail.handleImageContextMenu']])
+  await ExtensionDetail.handleImageContextMenu(100, 200)
+  expect(mockRpc.invocations).toEqual([['ExtensionDetail.handleImageContextMenu', 100, 200]])
 })
 
 test('hideSizeLink', async () => {


### PR DESCRIPTION
Pass click coordinates through the typed extension-detail image context-menu helper so e2e tests retain the original behavior.