### PR TITLE
feature: add markdown image error test api

### DIFF
--- a/packages/test-worker/src/parts/TestFrameWorkComponentExtensionDetail/TestFrameWorkComponentExtensionDetail.ts
+++ b/packages/test-worker/src/parts/TestFrameWorkComponentExtensionDetail/TestFrameWorkComponentExtensionDetail.ts
@@ -75,6 +75,10 @@ export const handleImageContextMenu = (x: number, y: number): Promise<void> => {
   return RendererWorker.invoke('ExtensionDetail.handleImageContextMenu', x, y)
 }
 
+export const handleMarkdownImageError = (src: string): Promise<void> => {
+  return RendererWorker.invoke('ExtensionDetail.handleMarkdownImageError', src)
+}
+
 export const openFeature = (featureName: string): Promise<void> => {
   return RendererWorker.invoke('ExtensionDetail.handleFeaturesClick', featureName)
 }

--- a/packages/test-worker/test/TestFrameWorkComponentExtensionDetail.test.ts
+++ b/packages/test-worker/test/TestFrameWorkComponentExtensionDetail.test.ts
@@ -165,6 +165,16 @@ test('handleImageContextMenu', async () => {
   expect(mockRpc.invocations).toEqual([['ExtensionDetail.handleImageContextMenu', 100, 200]])
 })
 
+test('handleMarkdownImageError', async () => {
+  using mockRpc = RendererWorker.registerMockRpc({
+    'ExtensionDetail.handleMarkdownImageError'() {
+      return undefined
+    },
+  })
+  await ExtensionDetail.handleMarkdownImageError('./not-found.png')
+  expect(mockRpc.invocations).toEqual([['ExtensionDetail.handleMarkdownImageError', './not-found.png']])
+})
+
 test('hideSizeLink', async () => {
   using mockRpc = RendererWorker.registerMockRpc({
     'ExtensionDetail.hideSizeLink'() {


### PR DESCRIPTION
## Summary

- add a typed ExtensionDetail.handleMarkdownImageError page-object API
- cover the renderer invocation with a unit test

## Validation

- focused test-worker suite (17 tests)
- type-check
- ESLint
- Prettier