### PR TITLE
feature: add github changelog test api

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3375,13 +3375,13 @@
       }
     },
     "node_modules/@lvce-editor/test-with-playwright": {
-      "version": "22.10.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/test-with-playwright/-/test-with-playwright-22.10.0.tgz",
-      "integrity": "sha512-TSa1MIZJvNk5I98YnFV3GxoQ5uEaKdveiPdkQjrSG+k/wFhXtfh5zOQj+eRlyliTJZTp66UxXfo8t80SrZzbEA==",
+      "version": "22.11.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/test-with-playwright/-/test-with-playwright-22.11.0.tgz",
+      "integrity": "sha512-tLZHRNn2ualXawje92iXtMQq3jmLrq7snK+ZRgH5IvqGRa/WkU7j7PANe/QphHOBJupDdYPeYn6TqRoTv5hWEg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@lvce-editor/test-with-playwright-worker": "22.10.0",
+        "@lvce-editor/test-with-playwright-worker": "22.11.0",
         "@lvce-editor/test-worker": "^17.5.0"
       },
       "bin": {
@@ -3392,9 +3392,9 @@
       }
     },
     "node_modules/@lvce-editor/test-with-playwright-worker": {
-      "version": "22.10.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/test-with-playwright-worker/-/test-with-playwright-worker-22.10.0.tgz",
-      "integrity": "sha512-4LWO0qXe+ZOh8FEn+8c5/7ZC7o3gMN4lOGbE5xHHldSF1kuTFcUgqkpViOgZDzjGt1Z3aB4ZrbK+pvDQpqsRRA==",
+      "version": "22.11.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/test-with-playwright-worker/-/test-with-playwright-worker-22.11.0.tgz",
+      "integrity": "sha512-kADGEmxrfDXveio6PEHGIerWh5qGH+gcV4CGV7++91+Tqu8AQgvuLxLzhcnb+GZuZAYydjocqVjlfuIXzVhwRg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -15709,7 +15709,7 @@
       "version": "0.0.0-dev",
       "license": "MIT",
       "devDependencies": {
-        "@lvce-editor/test-with-playwright": "^22.10.0"
+        "@lvce-editor/test-with-playwright": "^22.11.0"
       }
     },
     "packages/memory": {

--- a/packages/test-worker/src/parts/TestFrameWorkComponentExtensionDetail/TestFrameWorkComponentExtensionDetail.ts
+++ b/packages/test-worker/src/parts/TestFrameWorkComponentExtensionDetail/TestFrameWorkComponentExtensionDetail.ts
@@ -1,4 +1,5 @@
 import { RendererWorker } from '@lvce-editor/rpc-registry'
+import { addWebExtension } from '../TestFrameWorkComponentExtension/TestFrameWorkComponentExtension.ts'
 
 export interface GithubApiMock {
   readonly body?: unknown
@@ -8,6 +9,17 @@ export interface GithubApiMock {
   readonly status?: number
   readonly statusText?: string
   readonly type: 'generated' | 'invalid-json' | 'network-error' | 'response' | 'success'
+}
+
+export const createGithubRelease = (overrides: Readonly<Record<string, unknown>> = {}): Readonly<Record<string, unknown>> => {
+  return {
+    body: 'Fixed an important bug.',
+    html_url: 'https://github.com/test-owner/test-repository/releases/tag/v1.0.0',
+    name: 'Version 1.0.0',
+    published_at: '2026-01-02T03:04:05Z',
+    tag_name: 'v1.0.0',
+    ...overrides,
+  }
 }
 
 export const handleClickCategory = async (categoryId: string): Promise<void> => {
@@ -125,4 +137,11 @@ export const handleClickSettings = async (x: number, y: number): Promise<void> =
 
 export const mockGithubApi = async (options: GithubApiMock): Promise<void> => {
   await RendererWorker.invoke('ExtensionDetail.mockGithubApi', options)
+}
+
+export const openGithubChangelog = async (extensionUri: string, extensionId: string, options: GithubApiMock): Promise<void> => {
+  await addWebExtension(extensionUri)
+  await open(extensionId)
+  await mockGithubApi(options)
+  await selectChangelog()
 }

--- a/packages/test-worker/test/TestFrameWorkComponentExtensionDetail.test.ts
+++ b/packages/test-worker/test/TestFrameWorkComponentExtensionDetail.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from '@jest/globals'
-import { RendererWorker } from '@lvce-editor/rpc-registry'
+import { ExtensionManagementWorker, RendererWorker } from '@lvce-editor/rpc-registry'
 import * as ExtensionDetail from '../src/parts/TestFrameWorkComponentExtensionDetail/TestFrameWorkComponentExtensionDetail.ts'
 
 test('handleClickCategory', async () => {
@@ -217,4 +217,50 @@ test('mockGithubApi', async () => {
   } as const
   await ExtensionDetail.mockGithubApi(options)
   expect(mockRpc.invocations).toEqual([['ExtensionDetail.mockGithubApi', options]])
+})
+
+test('createGithubRelease', () => {
+  expect(ExtensionDetail.createGithubRelease({ name: 'Version 2.0.0' })).toEqual({
+    body: 'Fixed an important bug.',
+    html_url: 'https://github.com/test-owner/test-repository/releases/tag/v1.0.0',
+    name: 'Version 2.0.0',
+    published_at: '2026-01-02T03:04:05Z',
+    tag_name: 'v1.0.0',
+  })
+})
+
+test('openGithubChangelog', async () => {
+  using mockExtensionManagementRpc = ExtensionManagementWorker.registerMockRpc({
+    'Extensions.addWebExtension'() {
+      return undefined
+    },
+  })
+  using mockRpc = RendererWorker.registerMockRpc({
+    'ExtensionDetail.mockGithubApi'() {
+      return undefined
+    },
+    'ExtensionDetail.selectTab'() {
+      return undefined
+    },
+    'ExtensionMeta.addWebExtension'() {
+      return undefined
+    },
+    'Main.openUri'() {
+      return undefined
+    },
+  })
+  const options = {
+    body: [],
+    type: 'success',
+  } as const
+
+  await ExtensionDetail.openGithubChangelog('file:///extension', 'test.extension', options)
+
+  expect(mockExtensionManagementRpc.invocations).toEqual([['Extensions.addWebExtension', 'file:///extension']])
+  expect(mockRpc.invocations).toEqual([
+    ['ExtensionMeta.addWebExtension', 'file:///extension'],
+    ['Main.openUri', 'extension-detail://test.extension'],
+    ['ExtensionDetail.mockGithubApi', options],
+    ['ExtensionDetail.selectTab', 'Changelog'],
+  ])
 })


### PR DESCRIPTION
Adds typed ExtensionDetail helpers for creating GitHub release fixtures and opening a mocked GitHub changelog, so extension-detail e2e tests can use the shared page-object API.