### PR TITLE
feature: preload test modules in parallel

### DIFF
--- a/packages/test-worker/src/parts/Test/Test.ts
+++ b/packages/test-worker/src/parts/Test/Test.ts
@@ -32,6 +32,18 @@ interface ExecuteAllTestResult {
   readonly status: string
 }
 
+type ImportedExecuteAllTest =
+  | {
+      readonly item: ExecuteAllTest
+      readonly module: any
+      readonly type: 'success'
+    }
+  | {
+      readonly error: unknown
+      readonly item: ExecuteAllTest
+      readonly type: 'error'
+    }
+
 const toErrorMessage = (error: unknown): string => {
   if (error instanceof Error) {
     return error.message
@@ -83,9 +95,30 @@ const getExecutedResult = async (name: string, test: any, globals: any): Promise
   }
 }
 
-const executeAllTest = async (item: ExecuteAllTest, globals: any): Promise<ExecuteAllTestResult> => {
+const importExecuteAllTest = async (item: ExecuteAllTest): Promise<ImportedExecuteAllTest> => {
   try {
     const module = await ImportTest.importTest(item.url)
+    return {
+      item,
+      module,
+      type: 'success',
+    }
+  } catch (error) {
+    return {
+      error,
+      item,
+      type: 'error',
+    }
+  }
+}
+
+const executeAllTest = async (importedTest: ImportedExecuteAllTest, globals: any): Promise<ExecuteAllTestResult> => {
+  const { item } = importedTest
+  if (importedTest.type === 'error') {
+    return getImportErrorResult(item.name, importedTest.error)
+  }
+  try {
+    const { module } = importedTest
     const { mockRpc, skip, test } = module
     if (mockRpc) {
       TestState.setMockRpc(mockRpc)
@@ -219,8 +252,9 @@ export const executeAll = async (tests: readonly ExecuteAllTest[], href: string,
   const globals = createApi(platform, assetDir)
   const results: ExecuteAllTestResult[] = []
   const start = Timestamp.now()
-  for (const test of tests) {
-    const result = await executeAllTest(test, globals)
+  const importedTests = await Promise.all(tests.map(importExecuteAllTest))
+  for (const importedTest of importedTests) {
+    const result = await executeAllTest(importedTest, globals)
     results.push(result)
   }
   const end = Timestamp.now()

--- a/packages/test-worker/test/Test.test.ts
+++ b/packages/test-worker/test/Test.test.ts
@@ -228,6 +228,82 @@ export const test = async () => {}
   ])
 })
 
+test('executeAll imports test modules in parallel before executing them serially', async () => {
+  TestInfoCache.clear()
+  const assetDir = 'memfs://assets'
+  const events: string[] = []
+  const { promise: secondImportStarted, resolve: resolveSecondImportStarted } = Promise.withResolvers<void>()
+  Object.assign(globalThis, {
+    __parallelImportEvents: events,
+    __resolveSecondImportStarted: resolveSecondImportStarted,
+    __secondImportStarted: secondImportStarted,
+  })
+  const firstUrl = toDataUrl(`
+globalThis.__parallelImportEvents.push('import-first-start')
+await Promise.race([
+  globalThis.__secondImportStarted,
+  new Promise((_, reject) => setTimeout(() => reject(new Error('second module was not imported in parallel')), 100)),
+])
+globalThis.__parallelImportEvents.push('import-first-end')
+export const test = async () => {
+  globalThis.__parallelImportEvents.push('test-first-start')
+  await Promise.resolve()
+  globalThis.__parallelImportEvents.push('test-first-end')
+}
+`)
+  const secondUrl = toDataUrl(`
+globalThis.__parallelImportEvents.push('import-second-start')
+globalThis.__resolveSecondImportStarted()
+globalThis.__parallelImportEvents.push('import-second-end')
+export const test = async () => {
+  globalThis.__parallelImportEvents.push('test-second')
+}
+`)
+  const href = 'http://localhost:3000/tests/_all.html'
+
+  using mockRpc = RendererWorker.registerMockRpc({
+    'ActivityBar.resize'() {
+      return undefined
+    },
+    'Layout.reset'() {
+      return undefined
+    },
+    'TestFrameWork.showOverlay'() {
+      return undefined
+    },
+    'TestFrameWork.showTestResults'() {
+      return undefined
+    },
+  })
+
+  try {
+    await TestModule.executeAll(
+      [
+        { name: 'first-test.js', url: firstUrl },
+        { name: 'second-test.js', url: secondUrl },
+      ],
+      href,
+      1,
+      assetDir,
+    )
+  } finally {
+    delete (globalThis as any).__parallelImportEvents
+    delete (globalThis as any).__resolveSecondImportStarted
+    delete (globalThis as any).__secondImportStarted
+  }
+
+  expect(events).toEqual([
+    'import-first-start',
+    'import-second-start',
+    'import-second-end',
+    'import-first-end',
+    'test-first-start',
+    'test-first-end',
+    'test-second',
+  ])
+  expect(mockRpc.invocations).toHaveLength(6)
+})
+
 test('executeAll reports import errors in TestResults json', async () => {
   TestInfoCache.clear()
   const assetDir = 'memfs://assets'


### PR DESCRIPTION
Preload all reusable-page test modules concurrently before executing tests. Test execution and result ordering remain serial and deterministic, with per-module import failures preserved.