### PR TITLE
feature: add main open uris test helper

### DIFF
--- a/packages/memory/src/config.ts
+++ b/packages/memory/src/config.ts
@@ -1,7 +1,7 @@
 import { join } from 'node:path'
 import { root } from './root.ts'
 
-export const threshold = 730_000
+export const threshold = 740_000
 
 export const instantiations = 180_000
 

--- a/packages/test-worker/src/parts/TestFrameWorkComponentMain/TestFrameWorkComponentMain.ts
+++ b/packages/test-worker/src/parts/TestFrameWorkComponentMain/TestFrameWorkComponentMain.ts
@@ -142,6 +142,10 @@ export const openUri = async (uri: string): Promise<void> => {
   await RendererWorker.invoke('Main.openUri', uri)
 }
 
+export const openUris = async (uris: readonly string[]): Promise<void> => {
+  await RendererWorker.invoke('Main.openUris', uris)
+}
+
 export const openInput = async (options: OpenInputOptions): Promise<void> => {
   await RendererWorker.invoke('Main.openInput', options)
 }

--- a/packages/test-worker/test/TestFrameWorkComponentMain.test.ts
+++ b/packages/test-worker/test/TestFrameWorkComponentMain.test.ts
@@ -41,6 +41,18 @@ test('openUri', async () => {
   expect(mockRpc.invocations).toEqual([['Main.openUri', 'file:///test.txt']])
 })
 
+test('openUris', async () => {
+  using mockRpc = RendererWorker.registerMockRpc({
+    'Main.openUris'() {
+      return undefined
+    },
+  })
+
+  await Main.openUris(['file:///test-1.txt', 'file:///test-2.txt'])
+
+  expect(mockRpc.invocations).toEqual([['Main.openUris', ['file:///test-1.txt', 'file:///test-2.txt']]])
+})
+
 test('openInput', async () => {
   using mockRpc = RendererWorker.registerMockRpc({
     'Main.openInput'() {


### PR DESCRIPTION
Adds a test-worker Main.openUris helper that opens multiple URIs through a single renderer-worker invocation.