### PR TITLE
feature: add clipboard image assertion

### DIFF
--- a/packages/test-worker/src/parts/TestFrameWorkComponentClipBoard/TestFrameworkComponentClipBoard.ts
+++ b/packages/test-worker/src/parts/TestFrameWorkComponentClipBoard/TestFrameworkComponentClipBoard.ts
@@ -31,6 +31,36 @@ export const shouldHaveText = async (expectedText: string | RegExp): Promise<voi
   }
 }
 
+const findFirstDifferentByte = (actual: Uint8Array, expected: Uint8Array): number => {
+  const length = Math.min(actual.length, expected.length)
+  for (let index = 0; index < length; index++) {
+    if (actual[index] !== expected[index]) {
+      return index
+    }
+  }
+  return actual.length === expected.length ? -1 : length
+}
+
+export const shouldHaveImage = async (expectedUri: string): Promise<void> => {
+  const actualImage = await RendererWorker.invoke('ClipBoard.readMemoryImage')
+  if (!(actualImage instanceof Blob)) {
+    throw new AssertionError(`expected clipboard to have image "${expectedUri}" but it had no image`)
+  }
+  const expectedImage = await RendererWorker.invoke('FileSystem.getBlob', expectedUri)
+  if (!(expectedImage instanceof Blob)) {
+    throw new AssertionError(`expected image "${expectedUri}" could not be read`)
+  }
+  const [actualBuffer, expectedBuffer] = await Promise.all([actualImage.arrayBuffer(), expectedImage.arrayBuffer()])
+  const actualBytes = new Uint8Array(actualBuffer)
+  const expectedBytes = new Uint8Array(expectedBuffer)
+  const firstDifferentByte = findFirstDifferentByte(actualBytes, expectedBytes)
+  if (firstDifferentByte !== -1) {
+    throw new AssertionError(
+      `expected clipboard image to match "${expectedUri}" but contents differed at byte ${firstDifferentByte} (expected ${expectedBytes.length} bytes, got ${actualBytes.length})`,
+    )
+  }
+}
+
 export const writeText = async (text: string): Promise<void> => {
   await RendererWorker.invoke('ClipBoard.writeText', text)
 }

--- a/packages/test-worker/test/TestFrameWorkComponentClipBoard.test.ts
+++ b/packages/test-worker/test/TestFrameWorkComponentClipBoard.test.ts
@@ -102,6 +102,69 @@ test('shouldHaveText - wrong', async () => {
   expect(mockRpc.invocations).toEqual([['ClipBoard.readMemoryText']])
 })
 
+test('shouldHaveImage - correct', async () => {
+  const expectedUri = 'file:///expected.png'
+  const image = new Blob([new Uint8Array([1, 2, 3])], { type: 'image/png' })
+  using mockRpc = RendererWorker.registerMockRpc({
+    'ClipBoard.readMemoryImage'() {
+      return image
+    },
+    'FileSystem.getBlob'() {
+      return image
+    },
+  })
+
+  await ClipBoard.shouldHaveImage(expectedUri)
+
+  expect(mockRpc.invocations).toEqual([['ClipBoard.readMemoryImage'], ['FileSystem.getBlob', expectedUri]])
+})
+
+test('shouldHaveImage - no image', async () => {
+  const expectedUri = 'file:///expected.png'
+  using mockRpc = RendererWorker.registerMockRpc({
+    'ClipBoard.readMemoryImage'() {
+      return undefined
+    },
+  })
+
+  await expect(ClipBoard.shouldHaveImage(expectedUri)).rejects.toThrow(`expected clipboard to have image "${expectedUri}" but it had no image`)
+  expect(mockRpc.invocations).toEqual([['ClipBoard.readMemoryImage']])
+})
+
+test('shouldHaveImage - different contents', async () => {
+  const expectedUri = 'file:///expected.png'
+  using mockRpc = RendererWorker.registerMockRpc({
+    'ClipBoard.readMemoryImage'() {
+      return new Blob([new Uint8Array([1, 4, 3])], { type: 'image/png' })
+    },
+    'FileSystem.getBlob'() {
+      return new Blob([new Uint8Array([1, 2, 3])], { type: 'image/png' })
+    },
+  })
+
+  await expect(ClipBoard.shouldHaveImage(expectedUri)).rejects.toThrow(
+    `expected clipboard image to match "${expectedUri}" but contents differed at byte 1 (expected 3 bytes, got 3)`,
+  )
+  expect(mockRpc.invocations).toEqual([['ClipBoard.readMemoryImage'], ['FileSystem.getBlob', expectedUri]])
+})
+
+test('shouldHaveImage - different sizes', async () => {
+  const expectedUri = 'file:///expected.png'
+  using mockRpc = RendererWorker.registerMockRpc({
+    'ClipBoard.readMemoryImage'() {
+      return new Blob([new Uint8Array([1, 2])], { type: 'image/png' })
+    },
+    'FileSystem.getBlob'() {
+      return new Blob([new Uint8Array([1, 2, 3])], { type: 'image/png' })
+    },
+  })
+
+  await expect(ClipBoard.shouldHaveImage(expectedUri)).rejects.toThrow(
+    `expected clipboard image to match "${expectedUri}" but contents differed at byte 2 (expected 3 bytes, got 2)`,
+  )
+  expect(mockRpc.invocations).toEqual([['ClipBoard.readMemoryImage'], ['FileSystem.getBlob', expectedUri]])
+})
+
 test('shouldHaveText - regex success', async () => {
   using mockRpc = RendererWorker.registerMockRpc({
     'ClipBoard.readMemoryText'() {


### PR DESCRIPTION
Adds ClipBoard.shouldHaveImage(expectedUri) with exact byte comparison and focused unit coverage.