### PR TITLE
feature: clean up memory clipboard after tests

### DIFF
--- a/packages/test-worker/src/parts/ExecuteTest2/ExecuteTest2.ts
+++ b/packages/test-worker/src/parts/ExecuteTest2/ExecuteTest2.ts
@@ -2,6 +2,8 @@ import type { ExecuteTestResult } from '../ExecuteTestResult/ExecuteTestResult.t
 import { callFunction } from '../CallFunction/CallFunction.ts'
 import { ChatDebugShouldHavePayloadError } from '../ChatDebugShouldHavePayloadError/ChatDebugShouldHavePayloadError.ts'
 import { formatDuration } from '../FormatDuration/FormatDuration.ts'
+import * as MemoryClipBoardState from '../MemoryClipBoardState/MemoryClipBoardState.ts'
+import * as ClipBoard from '../TestFrameWorkComponentClipBoard/TestFrameworkComponentClipBoard.ts'
 import * as TestType from '../TestType/TestType.ts'
 
 const getAutoFixProperties = (error: any): any => {
@@ -28,7 +30,11 @@ const getAutoFixProperties = (error: any): any => {
 export const executeTest2 = async (name: string, fn: any, globals: any, timestampGenerator: () => number): Promise<ExecuteTestResult> => {
   const getTimestamp = timestampGenerator
   const start = getTimestamp()
-  const error = await callFunction(fn, globals)
+  let error = await callFunction(fn, globals)
+  if (MemoryClipBoardState.isEnabled()) {
+    const cleanupError = await callFunction(ClipBoard.disableMemoryClipBoard, undefined)
+    error ||= cleanupError
+  }
   const end = getTimestamp()
   const duration = end - start
   const formattedDuration = formatDuration(duration)

--- a/packages/test-worker/src/parts/MemoryClipBoardState/MemoryClipBoardState.ts
+++ b/packages/test-worker/src/parts/MemoryClipBoardState/MemoryClipBoardState.ts
@@ -1,0 +1,11 @@
+const state = {
+  enabled: false,
+}
+
+export const isEnabled = (): boolean => {
+  return state.enabled
+}
+
+export const setEnabled = (enabled: boolean): void => {
+  state.enabled = enabled
+}

--- a/packages/test-worker/src/parts/TestFrameWorkComponentClipBoard/TestFrameworkComponentClipBoard.ts
+++ b/packages/test-worker/src/parts/TestFrameWorkComponentClipBoard/TestFrameworkComponentClipBoard.ts
@@ -1,5 +1,6 @@
 import { RendererWorker } from '@lvce-editor/rpc-registry'
 import { AssertionError } from '../AssertionError/AssertionError.ts'
+import * as MemoryClipBoardState from '../MemoryClipBoardState/MemoryClipBoardState.ts'
 
 export const readNativeFiles = async (): Promise<void> => {
   await RendererWorker.invoke('ClipBoard.readNativeFiles')
@@ -11,10 +12,12 @@ export const writeNativeFiles = async (uris: readonly string[]): Promise<void> =
 
 export const enableMemoryClipBoard = async (): Promise<void> => {
   await RendererWorker.invoke('ClipBoard.enableMemoryClipBoard')
+  MemoryClipBoardState.setEnabled(true)
 }
 
 export const disableMemoryClipBoard = async (): Promise<void> => {
   await RendererWorker.invoke('ClipBoard.disableMemoryClipBoard')
+  MemoryClipBoardState.setEnabled(false)
 }
 
 const matchesExpectedText = (actualText: string, expectedText: string | RegExp): boolean => {

--- a/packages/test-worker/test/ExecuteTest2.test.ts
+++ b/packages/test-worker/test/ExecuteTest2.test.ts
@@ -1,6 +1,8 @@
 import { expect, test } from '@jest/globals'
+import { RendererWorker } from '@lvce-editor/rpc-registry'
 import { ChatDebugShouldHavePayloadError } from '../src/parts/ChatDebugShouldHavePayloadError/ChatDebugShouldHavePayloadError.ts'
 import * as ExecuteTest2 from '../src/parts/ExecuteTest2/ExecuteTest2.ts'
+import * as ClipBoard from '../src/parts/TestFrameWorkComponentClipBoard/TestFrameworkComponentClipBoard.ts'
 import * as TestType from '../src/parts/TestType/TestType.ts'
 
 const timestampGenerator1 = (): number => 1000
@@ -41,6 +43,15 @@ const testFunction7 = async (globals: any): Promise<void> => {
 }
 
 const timestampGenerator8 = (): number => 6000
+
+const enableMemoryClipBoard = async (): Promise<void> => {
+  await ClipBoard.enableMemoryClipBoard()
+}
+
+const enableAndDisableMemoryClipBoard = async (): Promise<void> => {
+  await ClipBoard.enableMemoryClipBoard()
+  await ClipBoard.disableMemoryClipBoard()
+}
 
 test('executeTest2 with successful test function', async () => {
   const globals = {}
@@ -160,4 +171,56 @@ test('executeTest2 adds autofix action for chat debug shouldHavePayload failures
       label: 'Autofix',
     },
   ])
+})
+
+test('executeTest2 disables the memory clipboard after a successful test', async () => {
+  using mockRpc = RendererWorker.registerMockRpc({
+    'ClipBoard.disableMemoryClipBoard'() {
+      return undefined
+    },
+    'ClipBoard.enableMemoryClipBoard'() {
+      return undefined
+    },
+  })
+  const result = await ExecuteTest2.executeTest2('memory-clipboard-test', enableMemoryClipBoard, {}, timestampGenerator1)
+
+  expect(result.type).toBe(TestType.Pass)
+  expect(mockRpc.invocations).toEqual([['ClipBoard.enableMemoryClipBoard'], ['ClipBoard.disableMemoryClipBoard']])
+})
+
+test('executeTest2 disables the memory clipboard after a failing test', async () => {
+  using mockRpc = RendererWorker.registerMockRpc({
+    'ClipBoard.disableMemoryClipBoard'() {
+      return undefined
+    },
+    'ClipBoard.enableMemoryClipBoard'() {
+      return undefined
+    },
+  })
+  const testError = new Error('Test failed')
+  const testFunction = async (): Promise<void> => {
+    await ClipBoard.enableMemoryClipBoard()
+    throw testError
+  }
+
+  const result = await ExecuteTest2.executeTest2('failing-memory-clipboard-test', testFunction, {}, timestampGenerator1)
+
+  expect(result.error).toBe(testError)
+  expect(result.type).toBe(TestType.Fail)
+  expect(mockRpc.invocations).toEqual([['ClipBoard.enableMemoryClipBoard'], ['ClipBoard.disableMemoryClipBoard']])
+})
+
+test('executeTest2 does not disable the memory clipboard twice', async () => {
+  using mockRpc = RendererWorker.registerMockRpc({
+    'ClipBoard.disableMemoryClipBoard'() {
+      return undefined
+    },
+    'ClipBoard.enableMemoryClipBoard'() {
+      return undefined
+    },
+  })
+  const result = await ExecuteTest2.executeTest2('manual-memory-clipboard-cleanup-test', enableAndDisableMemoryClipBoard, {}, timestampGenerator1)
+
+  expect(result.type).toBe(TestType.Pass)
+  expect(mockRpc.invocations).toEqual([['ClipBoard.enableMemoryClipBoard'], ['ClipBoard.disableMemoryClipBoard']])
 })

--- a/packages/test-worker/test/TestFrameWorkComponentClipBoard.test.ts
+++ b/packages/test-worker/test/TestFrameWorkComponentClipBoard.test.ts
@@ -1,9 +1,14 @@
-import { expect, jest, test } from '@jest/globals'
+import { afterEach, expect, jest, test } from '@jest/globals'
 import { RendererWorker } from '@lvce-editor/rpc-registry'
+import * as MemoryClipBoardState from '../src/parts/MemoryClipBoardState/MemoryClipBoardState.ts'
 import * as ClipBoard from '../src/parts/TestFrameWorkComponentClipBoard/TestFrameworkComponentClipBoard.ts'
 
 const helloNumberRegex = /Hello\D+\d+/
 const emailRegex = /test@example\.com/
+
+afterEach(() => {
+  MemoryClipBoardState.setEnabled(false)
+})
 
 test('readNativeFiles', async () => {
   using mockRpc = RendererWorker.registerMockRpc({
@@ -61,6 +66,7 @@ test('enableMemoryClipBoard', async () => {
   })
   await ClipBoard.enableMemoryClipBoard()
   expect(mockRpc.invocations).toEqual([['ClipBoard.enableMemoryClipBoard']])
+  expect(MemoryClipBoardState.isEnabled()).toBe(true)
 })
 
 test('disableMemoryClipBoard', async () => {
@@ -78,8 +84,10 @@ test('disableMemoryClipBoard', async () => {
       return undefined
     },
   })
+  MemoryClipBoardState.setEnabled(true)
   await ClipBoard.disableMemoryClipBoard()
   expect(mockRpc.invocations).toEqual([['ClipBoard.disableMemoryClipBoard']])
+  expect(MemoryClipBoardState.isEnabled()).toBe(false)
 })
 
 test('shouldHaveText - correct', async () => {


### PR DESCRIPTION
Tracks memory clipboard activation in the test worker and disables it automatically after each test, including failed tests. Manual cleanup remains safe and is not repeated.