### PR TITLE
feature: update eslint dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,11 +12,11 @@
         "packages/*"
       ],
       "devDependencies": {
-        "@lvce-editor/eslint-config": "^18.0.0",
+        "@lvce-editor/eslint-config": "^18.4.0",
         "@lvce-editor/eslint-plugin-regex": "^17.6.0",
         "@lvce-editor/eslint-plugin-tsconfig": "^17.6.0",
         "@types/node": "^25.9.3",
-        "eslint": "^10.8.0",
+        "eslint": "^10.8.1",
         "knip": "^6.29.0",
         "prettier": "^3.9.6",
         "typescript": "^6.0.3"
@@ -2685,9 +2685,9 @@
       }
     },
     "node_modules/@lvce-editor/eslint-config": {
-      "version": "18.0.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-config/-/eslint-config-18.0.0.tgz",
-      "integrity": "sha512-Q1GuQAuyRga4uuvLeucGZkV68QnDfFzNbqJ4F2q83iN1wWphnSsCn0Snwg7Ky+FmZ89bIh218cVdia63kMZhvQ==",
+      "version": "18.4.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-config/-/eslint-config-18.4.0.tgz",
+      "integrity": "sha512-Hni5Ub2jqyAQ3FgsGS3gk6PT/jKF5mS6oFZrqgDjJTcBf5nlZGg8WjEwpcyVUagVcrQPqrcJprEbImVvFUohFQ==",
       "dev": true,
       "license": "MIT",
       "workspaces": [
@@ -2699,16 +2699,16 @@
         "@eslint/js": "10.0.1",
         "@eslint/json": "2.0.1",
         "@eslint/markdown": "8.0.3",
-        "@lvce-editor/eslint-plugin-devcontainer": "18.0.0",
-        "@lvce-editor/eslint-plugin-e2e": "18.0.0",
-        "@lvce-editor/eslint-plugin-eslint-config": "18.0.0",
-        "@lvce-editor/eslint-plugin-extension-json": "18.0.0",
-        "@lvce-editor/eslint-plugin-github-actions": "18.0.0",
-        "@lvce-editor/eslint-plugin-nvmrc": "18.0.0",
-        "@lvce-editor/eslint-plugin-regex": "18.0.0",
-        "@lvce-editor/eslint-plugin-rpc": "18.0.0",
-        "@lvce-editor/eslint-plugin-tsconfig": "18.0.0",
-        "@lvce-editor/eslint-plugin-virtual-dom": "18.0.0",
+        "@lvce-editor/eslint-plugin-devcontainer": "18.4.0",
+        "@lvce-editor/eslint-plugin-e2e": "18.4.0",
+        "@lvce-editor/eslint-plugin-eslint-config": "18.4.0",
+        "@lvce-editor/eslint-plugin-extension-json": "18.4.0",
+        "@lvce-editor/eslint-plugin-github-actions": "18.4.0",
+        "@lvce-editor/eslint-plugin-nvmrc": "18.4.0",
+        "@lvce-editor/eslint-plugin-regex": "18.4.0",
+        "@lvce-editor/eslint-plugin-rpc": "18.4.0",
+        "@lvce-editor/eslint-plugin-tsconfig": "18.4.0",
+        "@lvce-editor/eslint-plugin-virtual-dom": "18.4.0",
         "eslint-plugin-jest": "29.15.4",
         "eslint-plugin-n": "18.2.1",
         "eslint-plugin-package-json": "1.5.0",
@@ -2722,28 +2722,17 @@
         "eslint": "^10"
       }
     },
-    "node_modules/@lvce-editor/eslint-config/node_modules/@lvce-editor/eslint-plugin-github-actions": {
-      "version": "18.0.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-plugin-github-actions/-/eslint-plugin-github-actions-18.0.0.tgz",
-      "integrity": "sha512-5lorIivbeHoc/iAYfCY6Y3XFJ0jNc7zsqxQroAInQUlhTIeK8BNCjnkQIv4J1UiUkR0peGjddqmKmLYiVTPuKw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "eslint-compat-utils": "0.6.5",
-        "yaml-eslint-parser": "2.1.0"
-      }
-    },
     "node_modules/@lvce-editor/eslint-config/node_modules/@lvce-editor/eslint-plugin-regex": {
-      "version": "18.0.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-plugin-regex/-/eslint-plugin-regex-18.0.0.tgz",
-      "integrity": "sha512-cuzNaGpak6XNsZSmJCLldougHiyjwGSZEEqxx3iCxrfW1/b1RCpaIuUBQGIdmBEF09Ql8QN3uHcnvaG1pl1LAw==",
+      "version": "18.4.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-plugin-regex/-/eslint-plugin-regex-18.4.0.tgz",
+      "integrity": "sha512-7A6AiK56pWt6s3eYkdC2heynXfKGAfOGsi7/xgT/Pvb91SJN5VheIl3WMGt2hcDWrsd5dUJfq5BWk7ZieSYyzw==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@lvce-editor/eslint-config/node_modules/@lvce-editor/eslint-plugin-tsconfig": {
-      "version": "18.0.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-plugin-tsconfig/-/eslint-plugin-tsconfig-18.0.0.tgz",
-      "integrity": "sha512-OibcGVrGkpgXkJBSs1Aix+rm6TlCBZuR3C4A0DdxJlABdPpKLeLYGpGaR8bIwBunnivmKjJPaYPA0KCRW8S+tw==",
+      "version": "18.4.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-plugin-tsconfig/-/eslint-plugin-tsconfig-18.4.0.tgz",
+      "integrity": "sha512-DgMtmiEr1t65qoObuq8vptXOx/Ucyk3aeJFoZdr9Ze8gwN0hUdFMyCZmNmVqN+tW06HJ+Drc2F1Ts8+SfCWOiA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2751,9 +2740,9 @@
       }
     },
     "node_modules/@lvce-editor/eslint-plugin-devcontainer": {
-      "version": "18.0.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-plugin-devcontainer/-/eslint-plugin-devcontainer-18.0.0.tgz",
-      "integrity": "sha512-NjgwH2NKwU3MFfsaMkf/eeOKlYdQMqhgyJiRvslhPcZL8lyzgVP5P88AE7pEXr/ZnamzEQOEtrtzH28Z1KBPjA==",
+      "version": "18.4.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-plugin-devcontainer/-/eslint-plugin-devcontainer-18.4.0.tgz",
+      "integrity": "sha512-+iItlCPV5Xj3c0q5iCZZR9nZeiFYNw/InwMYEj2CfHDi4XmJ+TSInMFyQSK6+GDMezD1okly7CDHyzM2YCpE9g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2761,33 +2750,44 @@
       }
     },
     "node_modules/@lvce-editor/eslint-plugin-e2e": {
-      "version": "18.0.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-plugin-e2e/-/eslint-plugin-e2e-18.0.0.tgz",
-      "integrity": "sha512-W5SvLvHQVWR5aV+QJPTT/QRPbBHEoFyYY8zbAeaxwP3TpHmhdrJTHY0Ser8ZAKC8VzxhvpWOaVokgJWGMH6dmA==",
+      "version": "18.4.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-plugin-e2e/-/eslint-plugin-e2e-18.4.0.tgz",
+      "integrity": "sha512-lg75DLSSrn9vt2p1OGkettK5CEOOZU+26hBEIaU1HKv5q8PgaM+jIhPF/g4KutMgq0F0qjXcika4tlPbQBFRGw==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@lvce-editor/eslint-plugin-eslint-config": {
-      "version": "18.0.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-plugin-eslint-config/-/eslint-plugin-eslint-config-18.0.0.tgz",
-      "integrity": "sha512-zZUDZdU8svl+cZ391YprAKNYULR/4nvtnJsDbi2RWEwhvixyXZLWEmakguFpav1g0xD+KfR95O+qddwtik3yow==",
+      "version": "18.4.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-plugin-eslint-config/-/eslint-plugin-eslint-config-18.4.0.tgz",
+      "integrity": "sha512-BW+7W4Gecp2CenHuVy5VRggIHjJ6vVhkJpL59XYRIf5TqFznEhVDW6iIipePL2kGtu/JnXh6162QE3rEpsJ7qg==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@lvce-editor/eslint-plugin-extension-json": {
-      "version": "18.0.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-plugin-extension-json/-/eslint-plugin-extension-json-18.0.0.tgz",
-      "integrity": "sha512-FWK97+EyJdgaocSo5eRbMLobOO0IsEYD7krxZdpP+VUHzkXKRg50dnDOThWdAVTBba4fq/ld3kURgsymuIfQDg==",
+      "version": "18.4.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-plugin-extension-json/-/eslint-plugin-extension-json-18.4.0.tgz",
+      "integrity": "sha512-jd86DG62e/DLvMWMh03byuBj/k9kOeWXRUSSuGTb9be0TsjKdKbeP8hDUFBrLD8osaNUMr5tfDsNZE19gDjA2Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint/json": "2.0.1"
       }
     },
+    "node_modules/@lvce-editor/eslint-plugin-github-actions": {
+      "version": "18.4.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-plugin-github-actions/-/eslint-plugin-github-actions-18.4.0.tgz",
+      "integrity": "sha512-HAkU0VXCXqiRSpKdGxjkHDBrV7w38uVtF4iOwpELffx6Olt97aJLz5/6nTZvJShv+BcdEgnvH1nnog0FN79tlQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eslint-compat-utils": "0.6.5",
+        "yaml-eslint-parser": "2.1.0"
+      }
+    },
     "node_modules/@lvce-editor/eslint-plugin-nvmrc": {
-      "version": "18.0.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-plugin-nvmrc/-/eslint-plugin-nvmrc-18.0.0.tgz",
-      "integrity": "sha512-ATg67BM6gcOt8f2AvabsKKh8NzZezN+lM19ZAoZUuVGClciVqDVibAjbvmlLnTy4vxWq8uyTDcTvAuS/A0PKOg==",
+      "version": "18.4.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-plugin-nvmrc/-/eslint-plugin-nvmrc-18.4.0.tgz",
+      "integrity": "sha512-wiv8PY1qn95Sxhy2PoplK9ZplEtjqSQWEzTWfWg3OkR5Kay8w1zf3JiTX86mhT4ic6BQ+A7d5hxgJ+T6H5EKuA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2815,9 +2815,9 @@
       "license": "MIT"
     },
     "node_modules/@lvce-editor/eslint-plugin-rpc": {
-      "version": "18.0.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-plugin-rpc/-/eslint-plugin-rpc-18.0.0.tgz",
-      "integrity": "sha512-c5SmTTzfKxL00a+CC5/Bz1pi1DZwXGVj2hOZszs70jVxKissYGaJXtlcuqC1LJXqzrUBJmcqe/cmlFlKIJhphg==",
+      "version": "18.4.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-plugin-rpc/-/eslint-plugin-rpc-18.4.0.tgz",
+      "integrity": "sha512-NkXd4SXwaKJHUfz0z7i+wrDXxcp9xZaPTuOs/Eyr8nMvdw7q6lU+B+wEZNuu0sM3l3uboiKhVbRIIlFN51InEg==",
       "dev": true,
       "license": "MIT"
     },
@@ -2832,9 +2832,9 @@
       }
     },
     "node_modules/@lvce-editor/eslint-plugin-virtual-dom": {
-      "version": "18.0.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-plugin-virtual-dom/-/eslint-plugin-virtual-dom-18.0.0.tgz",
-      "integrity": "sha512-ueMuPSpbG1iAU4CF1SB/vwX1RSkSgx9nue/89tzGmn9UzAwJfLU4neSc5b+zo9vTVnNQ+4Jp38VFbhoz1BgFsA==",
+      "version": "18.4.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-plugin-virtual-dom/-/eslint-plugin-virtual-dom-18.4.0.tgz",
+      "integrity": "sha512-DZ7gFfc06T2Ysf12vW3M6pGUzOQtxgSwdhkTasSqzvuxFKqN1vBw5koOzhPL5QjhMlLFY9u/ncMWq5CX+3s/8g==",
       "dev": true,
       "license": "MIT"
     },
@@ -3404,14 +3404,14 @@
       }
     },
     "node_modules/@lvce-editor/test-with-playwright": {
-      "version": "22.17.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/test-with-playwright/-/test-with-playwright-22.17.0.tgz",
-      "integrity": "sha512-yu8FuJ3Szx9F/OOkrO8zuSbT0+YHvQhNKKdT7HuqB9H5t+q4blReX1vZPVx46QzksAC/aPhi5NKlX+0zTYTjRg==",
+      "version": "22.22.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/test-with-playwright/-/test-with-playwright-22.22.0.tgz",
+      "integrity": "sha512-BcY0k7p/6OeCdxnVTb7AeQ17uZ3Me0+xyo8oTPwg0ZF+7cmY44ve6D8DwAvx6SmHGjrROuzoi3ebEPLn8ekdyw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@lvce-editor/test-with-playwright-worker": "22.17.0",
-        "@lvce-editor/test-worker": "^17.9.0"
+        "@lvce-editor/test-with-playwright-worker": "22.22.0",
+        "@lvce-editor/test-worker": "^17.12.1"
       },
       "bin": {
         "test-with-playwright": "bin/test-with-playwright.js"
@@ -3421,18 +3421,18 @@
       }
     },
     "node_modules/@lvce-editor/test-with-playwright-worker": {
-      "version": "22.17.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/test-with-playwright-worker/-/test-with-playwright-worker-22.17.0.tgz",
-      "integrity": "sha512-dIcKcNVvRED6SsTBV3Eb5RV0e2B0R69sbCy43NyzsVfZLWZNT4FO9WuwC2Xoob/jcZ3nvITdq3t44xpZ540MpQ==",
+      "version": "22.22.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/test-with-playwright-worker/-/test-with-playwright-worker-22.22.0.tgz",
+      "integrity": "sha512-UrcW97pG/I9+bkm7c+McOu9MbJ1Lza//xGbX8Tks/w1vISW3hc3qGyhTau/Eo0CGfUIfd4ppWysIzwglpRx1/w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@playwright/test": "1.61.1",
+        "@playwright/test": "1.62.1",
         "get-port": "^7.2.0",
         "istanbul-lib-coverage": "^3.2.2",
         "istanbul-lib-report": "^3.0.1",
         "istanbul-reports": "^3.2.0",
-        "playwright-core": "^1.61.1",
+        "playwright-core": "^1.62.1",
         "v8-to-istanbul": "^9.3.0"
       },
       "engines": {
@@ -3440,9 +3440,9 @@
       }
     },
     "node_modules/@lvce-editor/test-with-playwright/node_modules/@lvce-editor/test-worker": {
-      "version": "17.9.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/test-worker/-/test-worker-17.9.0.tgz",
-      "integrity": "sha512-+6ScdQNmOEJgQZU+SflmDMZuDOeL+FPNmz7el2iQKpPteOD2+Lu4WPCclnWti6PPSKAhjP71+vQU299sEixkKQ==",
+      "version": "17.12.1",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/test-worker/-/test-worker-17.12.1.tgz",
+      "integrity": "sha512-zmHIKpcTHRK5UkD99TQfbwRX2HnzyGpiiAIaOm9ZtEQDw0D8IfSwVwFnsyUmca/L7vVpoCWWjj0xN0EdcoU2wQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -4255,19 +4255,19 @@
       }
     },
     "node_modules/@playwright/test": {
-      "version": "1.61.1",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.61.1.tgz",
-      "integrity": "sha512-8nKv6+0RJSL9FE4jYOEGXnPeM/Hg12qZpmqzZjRh3qM0Y7c3z1mrOTfFLids72RDQYVh9WpLEfR5WdpNX4fkig==",
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.62.1.tgz",
+      "integrity": "sha512-DTcUc8qii+cpHvtOwggMtBRMjKZHXYWdw8syRYu2vtzuq4Wxphqq4NfCs5Zt44L6mA8rfDfj+PHnxFc/FeK6mQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright": "1.61.1"
+        "playwright": "1.62.1"
       },
       "bin": {
         "playwright": "cli.js"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
       }
     },
     "node_modules/@rollup/plugin-babel": {
@@ -8024,9 +8024,9 @@
       }
     },
     "node_modules/eslint": {
-      "version": "10.8.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.8.0.tgz",
-      "integrity": "sha512-nuKKvN+oIBO0koN7Tm7dlkmnkc21mtt0QJLwAKzjLq14y6lRTdVG36MZHJ8eQHwdJMwZbQNMlPOYedMq/oVJvQ==",
+      "version": "10.8.1",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.8.1.tgz",
+      "integrity": "sha512-wqA7W2jbsC/BnV9Iv1UZpKVFkO1AdNoSmYW8NWG4HNOBbkAMvIqDZ27pI2f07dqn583NcIC44ckjAcOXDL1QbQ==",
       "dev": true,
       "license": "MIT",
       "workspaces": [
@@ -13150,19 +13150,19 @@
       }
     },
     "node_modules/playwright": {
-      "version": "1.61.1",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.1.tgz",
-      "integrity": "sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==",
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.62.1.tgz",
+      "integrity": "sha512-0M+L3LAD8/nm554LOla9Ayx0j0tmFZ0FBcoQ7F1VuVHpM/XpiC8RcDzBQB8W5+hA8L22THxELzeF+2WcUzvcLg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright-core": "1.61.1"
+        "playwright-core": "1.62.1"
       },
       "bin": {
         "playwright": "cli.js"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
       },
       "optionalDependencies": {
         "fsevents": "2.3.2"
@@ -13194,19 +13194,6 @@
       ],
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
-      }
-    },
-    "node_modules/playwright/node_modules/playwright-core": {
-      "version": "1.61.1",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.1.tgz",
-      "integrity": "sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "bin": {
-        "playwright-core": "cli.js"
-      },
-      "engines": {
-        "node": ">=18"
       }
     },
     "node_modules/pluralize": {
@@ -15712,7 +15699,7 @@
       "version": "0.0.0-dev",
       "license": "MIT",
       "devDependencies": {
-        "@lvce-editor/test-with-playwright": "^22.17.0"
+        "@lvce-editor/test-with-playwright": "^22.22.0"
       }
     },
     "packages/memory": {

--- a/package.json
+++ b/package.json
@@ -23,11 +23,11 @@
     "printWidth": 150
   },
   "devDependencies": {
-    "@lvce-editor/eslint-config": "^18.0.0",
+    "@lvce-editor/eslint-config": "^18.4.0",
     "@lvce-editor/eslint-plugin-regex": "^17.6.0",
     "@lvce-editor/eslint-plugin-tsconfig": "^17.6.0",
     "@types/node": "^25.9.3",
-    "eslint": "^10.8.0",
+    "eslint": "^10.8.1",
     "knip": "^6.29.0",
     "prettier": "^3.9.6",
     "typescript": "^6.0.3"


### PR DESCRIPTION
Update ESLint and the shared LVCE ESLint config to their latest versions.

Also refresh the existing stale lockfile entries so clean installs succeed.

Validation:
- npm run lint
- npm run type-check
- npm test